### PR TITLE
Issue 142 - support masking results from get_gridded_data().

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.0.6"
+version = "1.0.7"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -1963,7 +1963,7 @@ def _read_and_filter_tiff_files(
     data_ds = xr.open_dataset(file_path)
     data_da = data_ds[variable]
     da_indexers = _create_da_indexer(options, entry, data_ds, data_da, file_path)
-    if _flip_da_indexers(entry, da_indexers):
+    if _flip_da_indexers_y(entry, da_indexers):
         # Select data with the flipped da_indexers and flip the result data
         data_da = data_da.isel(da_indexers)
         if len(data_da.shape) == 3:
@@ -1977,14 +1977,14 @@ def _read_and_filter_tiff_files(
     return data
 
 
-def _flip_da_indexers(entry, da_indexers) -> bool:
+def _flip_da_indexers_y(entry, da_indexers) -> bool:
     """
     Flip the y axis ranges of the da_indexers filter range.
     Parameters:
         entry:      The data catalog entry of the data being read.
         da_indexers:The data structure passed to xarray isel to select data.
     Returns:
-        True if flipped the da_indexers and the resulting numpy array also needs to be flipped.
+        True if flipped the da_indexers and the resulting numpy array also needs to be flipped on Y axis.
 
     This is called for TIFF files before subsetting a TIFF file using xarray Data Array.
     The da_indexers contains the x,y ranges of indexes to be used for subsetting.

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -1309,7 +1309,6 @@ def _apply_mask(data, entry, options):
                 "level": 2,
             }
         )
-        # print(np.where(mask == np.nan))
         data = np.where(mask, np.nan, data)
     return data
 
@@ -1436,8 +1435,11 @@ def get_huc_bbox(grid: str, huc_id_list: List[str]) -> List[int]:
             np.argmax(diffed_y_mask.values) + 1
         )  # because of the point you actually want to indicate from the diff function
 
-        jmin = tiff_ds.shape[1] - arr_jmax
-        jmax = tiff_ds.shape[1] - arr_jmin
+        #jmin = tiff_ds.shape[1] - arr_jmax
+        #jmax = tiff_ds.shape[1] - arr_jmin
+
+        jmin = arr_jmin
+        jmax = arr_jmax
 
         # Do the exact same thing for the x dimension
         diffed_x_mask = (sel_huc.sum(dim="y") > 0).astype(int).diff(dim="x")

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -1985,9 +1985,14 @@ def _flip_da_indexers(entry, da_indexers) -> bool:
         da_indexers:The data structure passed to xarray isel to select data.
     Returns:
         True if flipped the da_indexers and the resulting numpy array also needs to be flipped.
-    This is performed when the data is a tiff file that is stored with y origin at top left.
-    The data read from the file is flipped so the returned array has the same coodinates as PFB and NetCDF.
-    Do not flip conus2_current_conditions water_table_depth because this tiff is not flipped.
+
+    This is called for TIFF files before subsetting a TIFF file using xarray Data Array.
+    The da_indexers contains the x,y ranges of indexes to be used for subsetting.
+    A TIFF file by convention is an array stored with the origin in the top left instead of bottom left.
+    The da_indexers parameter contains the subset ranges of a grid_bounds assuming origin is bottom left.
+    This function fixes the da_indexers by swaping on the Y dimension to subset the correct data.
+
+    Do not flip conus2_current_conditions water_table_depth because this TIFF file is already origin bottom left.
     """
     if entry["dataset"] == "conus2_current_conditions":
         return False

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -1453,7 +1453,7 @@ def get_huc_bbox(grid: str, huc_id_list: List[str]) -> List[int]:
         result_jmin = jmin if jmin < result_jmin else result_jmin
         result_jmax = jmax if jmax > result_jmax else result_jmax
 
-    return [result_imin, result_jmin, result_imax, result_jmax]
+    return [int(result_imin), int(result_jmin), int(result_imax), int(result_jmax)]
 
 
 def _verify_time_in_range(entry: dict, options: dict):

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -865,17 +865,17 @@ def test_get_huc_bbox_conus2():
 
     gr.HYDRODATA = "/hydrodata"
     bbox = hf.get_huc_bbox("conus2", ["1019000404"])
-    assert bbox == [1468, 1664, 1550, 1693]
+    assert bbox == [1468, 1563, 1550, 1592]
     bbox = hf.get_huc_bbox("conus2", ["10190004"])
-    assert bbox == [1468, 1664, 1550, 1693]
+    assert bbox == [1468, 1563, 1550, 1592]
     bbox = hf.get_huc_bbox("conus2", ["101900"])
-    assert bbox == [1439, 1573, 1844, 1851]
+    assert bbox == [1439, 1405, 1844, 1683]
     bbox = hf.get_huc_bbox("conus2", ["1019"])
-    assert bbox == [1439, 1573, 1844, 1851]
+    assert bbox == [1439, 1405, 1844, 1683]
     bbox = hf.get_huc_bbox("conus2", ["10"])
-    assert bbox == [948, 1353, 2741, 2784]
+    assert bbox == [948, 472, 2741, 1903]
     bbox = hf.get_huc_bbox("conus2", ["15020018"])
-    assert bbox == [940, 1333, 1060, 1422]
+    assert bbox == [940, 1834, 1060, 1923]
 
 
 def test_latlng_to_grid_out_of_bounds():
@@ -1142,10 +1142,10 @@ def test_get_huc_bbox_conus1():
         hf.get_huc_bbox("conus1", ["1019000404", "123"])
 
     bbox = hf.get_huc_bbox("conus1", ["1019000404"])
-    assert bbox == [1076, 720, 1124, 739]
+    assert bbox == [1076, 1149, 1124, 1168]
 
     bbox = hf.get_huc_bbox("conus1", ["1102001002", "1102001003"])
-    assert bbox == [1088, 415, 1132, 453]
+    assert bbox == [1088, 1435, 1132, 1473]
 
 
 def test_getndarray_site_id():

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -865,17 +865,17 @@ def test_get_huc_bbox_conus2():
 
     gr.HYDRODATA = "/hydrodata"
     bbox = hf.get_huc_bbox("conus2", ["1019000404"])
-    assert bbox == [1468, 1563, 1550, 1592]
+    assert bbox == [1468, 1664, 1550, 1693]
     bbox = hf.get_huc_bbox("conus2", ["10190004"])
-    assert bbox == [1468, 1563, 1550, 1592]
+    assert bbox == [1468, 1664, 1550, 1693]
     bbox = hf.get_huc_bbox("conus2", ["101900"])
-    assert bbox == [1439, 1405, 1844, 1683]
+    assert bbox == [1439, 1573, 1844, 1851]
     bbox = hf.get_huc_bbox("conus2", ["1019"])
-    assert bbox == [1439, 1405, 1844, 1683]
+    assert bbox == [1439, 1573, 1844, 1851]
     bbox = hf.get_huc_bbox("conus2", ["10"])
-    assert bbox == [948, 472, 2741, 1903]
+    assert bbox == [948, 1353, 2741, 2784]
     bbox = hf.get_huc_bbox("conus2", ["15020018"])
-    assert bbox == [940, 1834, 1060, 1923]
+    assert bbox == [940, 1333, 1060, 1422]
 
 
 def test_latlng_to_grid_out_of_bounds():
@@ -1142,10 +1142,10 @@ def test_get_huc_bbox_conus1():
         hf.get_huc_bbox("conus1", ["1019000404", "123"])
 
     bbox = hf.get_huc_bbox("conus1", ["1019000404"])
-    assert bbox == [1076, 1149, 1124, 1168]
+    assert bbox == [1076, 720, 1124, 739]
 
     bbox = hf.get_huc_bbox("conus1", ["1102001002", "1102001003"])
-    assert bbox == [1088, 1435, 1132, 1473]
+    assert bbox == [1088, 415, 1132, 453]
 
 
 def test_getndarray_site_id():
@@ -1498,7 +1498,7 @@ def test_huc_border():
         "mask": "true",
     }
     data = gr.get_gridded_data(options)
-    assert math.isnan(data[0, 0, 0])
+    assert math.isnan(data[0, 0, 98])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
if the option "mask":"true" is specified to the function get_gridded_data() then mask the result by the HUC specified by the "huc_id" option. If grid_bounds or lat long_bounds is specified then mask the result by the conus borders contained in the bounds.

Also, when a TIFF file is generated by get_gridded_files() write the file using the origin at top left as is typical for tiff files. This is the implementation for issue-142.

Verify with new unit tests. Also verify on Verde with hydrodata using get_gridded_files() to generate and display tiff files with mask:true to verify that the image is masked by the call to get_gridded_data from get_gridded_files().