### PR TITLE
Fix issues with get_gridded_files reading 2D tiff files and some thread safety issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.0.9"
+version = "1.0.10"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"


### PR DESCRIPTION
Fix some issues with get_gridded_files reading 2D tiff files.
Add thread lock protection around calls to xarray open_dataset. The open_dataset call in xarray is not thread safe even though using the dataset returned by open_dataset is thread safe.