### PR TITLE
Add PFB topographic_index entry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.1.2"
+version = "1.1.3"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -2132,13 +2132,9 @@ def _slice_da_bounds(da: xr.DataArray, grid: str, options: dict) -> xr.DataArray
 
     if grid_bounds:
         if len(da.shape) == 3:
-            result = da[
-                :, grid_bounds[1] : grid_bounds[3], grid_bounds[0] : grid_bounds[2]
-            ]
+            result = da[:, grid_bounds[1] : grid_bounds[3], grid_bounds[0] : grid_bounds[2]]
         elif len(da.shape) == 2:
-            result = da[
-                grid_bounds[1] : grid_bounds[3], grid_bounds[0] : grid_bounds[2]
-            ]
+            result = da[grid_bounds[1] : grid_bounds[3], grid_bounds[0] : grid_bounds[2]]
         else:
             raise ValueError(f"Unsupported shape size {len(da.shape)}")
     else:

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -624,7 +624,8 @@ def get_gridded_files(
                     filename_template, entry, options, file_time, start_time
                 )
                 if file_name.endswith(".nc") and not file_name == last_file_name:
-                    _execute_dask_items(dask_items, state, last_file_name)
+                    if last_file_name:
+                        _execute_dask_items(dask_items, state, last_file_name)
                     state = _FileDownloadState(
                         options_copy,
                         filename_template,
@@ -785,7 +786,11 @@ def _create_gridded_files_netcdf(
         elif len(data.shape) == 2 and not state.temporal_resolution == "static":
             nc_data[t_num, :, :] = data[:, :]
         elif len(data.shape) == 2 and state.temporal_resolution == "static":
-            nc_data[:, :] = data[:, :]
+            if isinstance(data, xr.DataArray):
+                nc_data = data
+            else:
+                nc_data[:, :] = data[:, :]
+            print("Done")
         else:
             raise ValueError("Bad shape of data returned from API.")
 
@@ -2126,7 +2131,16 @@ def _slice_da_bounds(da: xr.DataArray, grid: str, options: dict) -> xr.DataArray
         )
 
     if grid_bounds:
-        result = da[:, grid_bounds[1] : grid_bounds[3], grid_bounds[0] : grid_bounds[2]]
+        if len(da.shape) == 3:
+            result = da[
+                :, grid_bounds[1] : grid_bounds[3], grid_bounds[0] : grid_bounds[2]
+            ]
+        elif len(da.shape) == 2:
+            result = da[
+                grid_bounds[1] : grid_bounds[3], grid_bounds[0] : grid_bounds[2]
+            ]
+        else:
+            raise ValueError(f"Unsupported shape size {len(da.shape)}")
     else:
         result = da
     return result

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -790,7 +790,6 @@ def _create_gridded_files_netcdf(
                 nc_data = data
             else:
                 nc_data[:, :] = data[:, :]
-            print("Done")
         else:
             raise ValueError("Bad shape of data returned from API.")
 

--- a/src/hf_hydrodata/model/data_catalog_entry.csv
+++ b/src/hf_hydrodata/model/data_catalog_entry.csv
@@ -87,7 +87,6 @@ id,dataset,file_type,variable,dataset_var,entry_start_date,entry_end_date,tempor
 86,conus1_domain,pfb,permeability,permeability,,,static,m/h,-,conus1,,1,/hydrodata/PFCLM/CONUS1_baseline/simulations/static/CONUS1_permeability.pfb,,
 87,conus1_domain,pfb,drainage_area,drainage_area,,,static,km2,-,conus1,,1,/hydrodata/PFCLM/CONUS1_baseline/simulations/static/CONUS1_drainage_area.pfb,,
 88,conus1_domain,pfb,veg_type_IGBP,vegetation_type,,,static,-,-,conus1,,1,/hydrodata/PFCLM/CONUS1_baseline/simulations/static/CONUS1_vegtype.pfb,,
-89,conus1_domain,pfmetadata,topographic_index,topographic_index,,,static,-,-,conus1,,1,/hydrodata/PFCLM/CONUS1_baseline/simulations/static/conus1_parameters.pfmetadata,,
 90,conus1_domain,pfb,pme,pme,,,static,m/h,-,conus1,,1,/hydrodata/PFCLM/CONUS1_baseline/inputs/PmE.flux.pfb,PmE that was used for CONUS1 steady state spinup,
 91,conus1_domain,pftxt,elevation,elevation,,,static,m,-,conus1,,1,/hydrodata/PFCLM/CONUS1_baseline/inputs/CONUS.pitfill.txt,Processed surface elevaiton for every grid cell this is what was used to calculate the slopes,
 92,conus1_domain,pftxt,stream_order,stream_order,,,static,-,-,conus1,,1,/hydrodata/PFCLM/CONUS1_baseline/other_domain_files/StreamOrder_pfFormat.txt,Stream orders are assigned for every subbasin. Headwaters and non-river cells are assigned a value of zero . The order for all other streams was determined by walking downstream from the headwater reaches. Streams are assigned the largest order possible (i.e. the longest route to get to them).,
@@ -396,3 +395,4 @@ id,dataset,file_type,variable,dataset_var,entry_start_date,entry_end_date,tempor
 518,noaa,pfb,air_temp,Temp_min,,,daily,K,min,conus1,wy_daynum,1,/hydrodata/national_obs/gridded_meteorology/NOAA_temperature/CONUS1/WY{wy}/HRRR.Temp_min.daily.regrid.{wy}.{wy_daynum:03d}.pfb,,
 519,noaa,pfb,air_temp,Temp_max,,,daily,K,max,conus1,wy_daynum,1,/hydrodata/national_obs/gridded_meteorology/NOAA_temperature/CONUS1/WY{wy}/HRRR.Temp_max.daily.regrid.{wy}.{wy_daynum:03d}.pfb,,
 520,noaa,pfb,air_temp,Temp_mean,,,daily,K,mean,conus1,wy_daynum,1,/hydrodata/national_obs/gridded_meteorology/NOAA_temperature/CONUS1/WY{wy}/HRRR.Temp_mean.daily.regrid.{wy}.{wy_daynum:03d}.pfb,,
+521,conus1_domain,pfb,topographic_index,topographic_index,,,static,-,static,conus1,,3,/hydrodata/PFCLM/CONUS1_baseline/simulations/static/CONUS1_topographic_index.pfb,,

--- a/src/hf_hydrodata/model/data_catalog_entry.csv
+++ b/src/hf_hydrodata/model/data_catalog_entry.csv
@@ -395,4 +395,4 @@ id,dataset,file_type,variable,dataset_var,entry_start_date,entry_end_date,tempor
 518,noaa,pfb,air_temp,Temp_min,,,daily,K,min,conus1,wy_daynum,1,/hydrodata/national_obs/gridded_meteorology/NOAA_temperature/CONUS1/WY{wy}/HRRR.Temp_min.daily.regrid.{wy}.{wy_daynum:03d}.pfb,,
 519,noaa,pfb,air_temp,Temp_max,,,daily,K,max,conus1,wy_daynum,1,/hydrodata/national_obs/gridded_meteorology/NOAA_temperature/CONUS1/WY{wy}/HRRR.Temp_max.daily.regrid.{wy}.{wy_daynum:03d}.pfb,,
 520,noaa,pfb,air_temp,Temp_mean,,,daily,K,mean,conus1,wy_daynum,1,/hydrodata/national_obs/gridded_meteorology/NOAA_temperature/CONUS1/WY{wy}/HRRR.Temp_mean.daily.regrid.{wy}.{wy_daynum:03d}.pfb,,
-521,conus1_domain,pfb,topographic_index,topographic_index,,,static,-,static,conus1,,3,/hydrodata/PFCLM/CONUS1_baseline/simulations/static/CONUS1_topographic_index.pfb,,
+521,conus1_domain,pfb,topographic_index,topographic_index,,,static,-,-,conus1,,1,/hydrodata/PFCLM/CONUS1_baseline/simulations/static/CONUS1_topographic_index.pfb,,

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -1124,7 +1124,7 @@ def test_ambiguous_filter():
 
     with pytest.raises(ValueError) as info:
         hf.get_catalog_entry(options)
-    assert "variable = 'precipitation' or 'downward_longwave" in str(info.value)
+    assert "variable = '" in str(info.value) and "'downward_longwave" in str(info.value)
 
 
 def test_get_huc_from_point():
@@ -1649,6 +1649,27 @@ def test_noaa_temp():
     data = hf.get_gridded_data(options)
     assert data.shape == (2, 5, 5)
     assert round(data[0, 0, 0], 3) == 265.25
+
+
+def test_topographic_index():
+    """Unit test topographic_index variable."""
+    cd = os.getcwd()
+    with tempfile.TemporaryDirectory() as tempdirname:
+        os.chdir(tempdirname)
+
+        bounds = [1000, 1000, 1005, 1005]
+        options = {
+            "dataset": "conus1_domain",
+            "grid_bounds": bounds,
+            "variable": "topographic_index",
+        }
+        hf.get_gridded_files(options, filename_template="foo.nc")
+        ds = xr.open_dataset("foo.nc")
+        da = ds["topographic_index"]
+        assert da.shape == (5, 5)
+        print(ds)
+        print(da.shape)
+    os.chdir(cd)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added an entry to the data catalog for a file used by hydrogen emulator static parameters.
* Added the PFB entry for topographic_index variable for conus1.
* Fixed the code that picks preferred entries when there are multiple file_types for a filter. The old code didn't work with two many options that was triggered by adding this new entry
* Fixed some code when reading 2D static files triggered by reading this new static PFB file. 
* Removed entry 89 from data catalog that was a duplicate entry for topographic_index variable for pfmetadata files.
