### PR TITLE
Rename conus mapping variables

### DIFF
--- a/docs/source/available_metadata.rst
+++ b/docs/source/available_metadata.rst
@@ -89,14 +89,14 @@ There are several variables that are returned by all ``get_point_metadata()`` fu
       - String representation of the site's time zone, if provided by the contributing agency.
     * - doi
       - If applicable, the DOI associated with the site, as provided by the contributing agency.
-    * - conus1_x
-      - Constructed value that maps the site's latitude/longitude to the CONUS1 grid.
-    * - conus1_y
-      - Constructed value that maps the site's latitude/longitude to the CONUS1 grid.
-    * - conus2_x
-      - Constructed value that maps the site's latitude/longitude to the CONUS2 grid.
-    * - conus2_y
-      - Constructed value that maps the site's latitude/longitude to the CONUS2 grid.
+    * - conus1_i
+      - Integer number of grid cells in the horizonal direction away from the CONUS1 grid origin of (0,0).
+    * - conus1_j
+      - Integer number of grid cells in the vertical direction away from the CONUS1 grid origin of (0,0).
+    * - conus2_i
+      - Integer number of grid cells in the horizonal direction away from the CONUS2 grid origin of (0,0).
+    * - conus2_j
+      - Integer number of grid cells in the vertical direction away from the CONUS2 grid origin of (0,0).
 
 
 Stream Gage Metadata

--- a/docs/source/point_data/point_methods.rst
+++ b/docs/source/point_data/point_methods.rst
@@ -41,7 +41,7 @@ attributes are available in :ref:`point_obs_metadata`. ::
     data_source = 'usgs_nwis'
     variable = 'streamflow'
     temporal_resolution = 'daily'
-    aggregation = 'average'
+    aggregation = 'mean'
 
     # Get the metadata about the sites with returned data
     metadata = get_point_metadata(dataset = "usgs_nwis", variable = "streamflow", 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.1.3"
+version = "1.1.4"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/point.py
+++ b/src/hf_hydrodata/point.py
@@ -370,7 +370,7 @@ def get_point_metadata(*args, **kwargs):
 
     if "stream gauge" in metadata_df["site_type"].unique():
         attributes_df = pd.read_sql_query(
-            """SELECT site_id, conus1_x, conus1_y, conus2_x, conus2_y,
+            """SELECT site_id, conus1_i, conus1_j, conus2_i, conus2_j,
                       gages_drainage_sqkm AS gagesii_drainage_area,
                       class AS gagesii_class,
                       site_elevation_meters AS gagesii_site_elevation,
@@ -384,7 +384,7 @@ def get_point_metadata(*args, **kwargs):
 
     if "groundwater well" in metadata_df["site_type"].unique():
         attributes_df = pd.read_sql_query(
-            """SELECT site_id, conus1_x, conus1_y, conus2_x, conus2_y,
+            """SELECT site_id, conus1_i, conus1_j, conus2_i, conus2_j,
                       nat_aqfr_cd AS usgs_nat_aqfr_cd,
                       aqfr_cd AS usgs_aqfr_cd,
                       aqfr_type_cd AS usgs_aqfr_type_cd,
@@ -402,7 +402,7 @@ def get_point_metadata(*args, **kwargs):
         "SCAN station" in metadata_df["site_type"].unique()
     ):
         attributes_df = pd.read_sql_query(
-            """SELECT site_id, conus1_x, conus1_y, conus2_x, conus2_y,
+            """SELECT site_id, conus1_i, conus1_j, conus2_i, conus2_j,
                       elevation AS usda_elevation
                FROM snotel_station_attributes WHERE site_id IN (%s)"""
             % ",".join("?" * len(site_ids)),
@@ -413,7 +413,7 @@ def get_point_metadata(*args, **kwargs):
 
     if "flux tower" in metadata_df["site_type"].unique():
         attributes_df = pd.read_sql_query(
-            """SELECT site_id, conus1_x, conus1_y, conus2_x, conus2_y,
+            """SELECT site_id, conus1_i, conus1_j, conus2_i, conus2_j,
                       site_description AS ameriflux_site_description,
                       elevation AS ameriflux_elevation,
                       tower_type AS ameriflux_tower_type,


### PR DESCRIPTION
Renames conus x/y variables to conus i/j to reflect that they represent the integer number of grid cells away from the named conus grid origin.