### PR TITLE
fix bug when omitting temporal_resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.1.6"
+version = "1.1.7"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/point.py
+++ b/src/hf_hydrodata/point.py
@@ -699,7 +699,6 @@ def get_site_variables(*args, **kwargs):
             for s in options["site_ids"]:
                 param_list.append(s)
         elif isinstance(options["site_ids"], str):
-            print(f"site_ids {options['site_ids']}")
             site_query = """ AND s.site_id == ?"""
             param_list.append(options["site_ids"])
         else:
@@ -1954,8 +1953,6 @@ def _get_data_nc(site_list, var_id, *args, **kwargs):
     if "date_end" in options:
         date_end_dt = np.datetime64(options["date_end"])
 
-    print("collecting data...")
-
     for i in range(len(site_list)):
         # open single site file
         temp = xr.open_dataset(file_list[i])[varname]
@@ -1990,8 +1987,6 @@ def _get_data_nc(site_list, var_id, *args, **kwargs):
 
     ds = ds.assign_coords({"site": (site_list)})
     ds = ds.rename({"datetime": "date"})
-
-    print("data collected.")
 
     data_df = _convert_to_pandas(ds)
     if "min_num_obs" in options and options["min_num_obs"] is not None:

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -1678,10 +1678,30 @@ def test_topographic_index():
         ds = xr.open_dataset("foo.nc")
         da = ds["topographic_index"]
         assert da.shape == (5, 5)
-        print(ds)
-        print(da.shape)
     os.chdir(cd)
 
+def test_gridded_files_default_temporal_resolution():
+    """Test reading gridded files without specifing temporal resolution."""
+    
+    cd = os.getcwd()
+    with tempfile.TemporaryDirectory() as tempdirname:
+        os.chdir(tempdirname)
+        options = {
+            "dataset": "conus1_current_conditions",
+            "variable": "soil_moisture",
+            "grid_bounds": [100, 100, 104, 104],
+            "start_time": "2024-03-01",
+            "end_time": "2024-03-03",
+        }
+        variables = ["soil_moisture"]
+        gr.get_gridded_files(options, filename_template="foo.nc", variables = variables)
+        assert os.path.exists("foo.nc")
+    os.chdir(cd)
 
+    assert gr._get_temporal_resolution_from_catalog(options) == "daily"
+    
+    with pytest.raises(ValueError):
+        gr._get_temporal_resolution_from_catalog({"dataset": "CW3E"})
+    
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Fix a bug that occurs if you omit temporal_resolution from a call to get_gridded_files(), but when the temporal_resolution is not ambiguous and is unnecessary to pass to the function.

Also removed some print() statements left in from some previous commits.
