### PR TITLE
Add variables to point.get_site_variables() output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.1.9"
+version = "1.1.10"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/point.py
+++ b/src/hf_hydrodata/point.py
@@ -14,6 +14,7 @@ import numpy as np
 import requests
 import shapefile
 import pyproj
+import warnings
 from shapely import contains_xy
 from shapely.geometry import Point, shape
 from shapely.ops import transform
@@ -801,7 +802,6 @@ def get_site_variables(*args, **kwargs):
 
     # Map var_id into variable, temporal_resolution, aggregation
     variables = _get_variables(conn)
-    conn.close()
     merged = pd.merge(df, variables, on="var_id", how="left")
 
     # Add filter based on variable name
@@ -854,6 +854,29 @@ def get_site_variables(*args, **kwargs):
     ]
 
     final_df = final_df[ordered_cols]
+
+    # Merge on conus grid mappings
+    final_site_list = list(final_df["site_id"].unique())
+    conus_map_df = pd.DataFrame(
+        columns=(["site_id", "conus1_i", "conus1_j", "conus2_i", "conus2_j"])
+    )
+
+    for tbl in SITE_ATTRIBUTE_TABLES:
+        conus_map_query = f"""SELECT site_id, conus1_i, conus1_j, conus2_i, conus2_j
+                              FROM {tbl}
+                              WHERE site_id IN (%s)""" % ",".join(
+            "?" * len(final_site_list)
+        )
+        tbl_df = pd.read_sql_query(conus_map_query, conn, params=final_site_list)
+        if len(tbl_df) > 0:
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=FutureWarning)
+                conus_map_df = pd.concat(
+                    [conus_map_df, tbl_df], axis=0, ignore_index=True
+                )
+
+    final_df = pd.merge(final_df, conus_map_df, on="site_id", how="left")
+    conn.close()
     return final_df
 
 

--- a/src/hf_hydrodata/point.py
+++ b/src/hf_hydrodata/point.py
@@ -821,14 +821,13 @@ def get_site_variables(*args, **kwargs):
     final_df = merged.drop(
         columns=[
             "var_id",
-            "temporal_resolution",
             "variable_type",
-            "variable",
-            "aggregation",
-            "data_source",
             "depth_level",
         ]
     )
+
+    # Rename "data_source" to "dataset"
+    final_df = final_df.rename(columns={"data_source": "dataset"})
 
     # Re-order final columns
     ordered_cols = [
@@ -839,6 +838,10 @@ def get_site_variables(*args, **kwargs):
         "state",
         "variable_name",
         "units",
+        "dataset",
+        "variable",
+        "temporal_resolution",
+        "aggregation",
         "first_date_data_available",
         "last_date_data_available",
         "record_count",

--- a/tests/hf_hydrodata/test_point.py
+++ b/tests/hf_hydrodata/test_point.py
@@ -1065,7 +1065,7 @@ def test_get_variables_lat_lon():
     df = point.get_site_variables(latitude_range=(47, 50), longitude_range=(-75, -60))
 
     # Bounds are flexible for if more sites are added
-    assert (len(df) >= 36) & (len(df) <= 65)
+    assert (len(df) >= 36) & (len(df) <= 85)
     assert "01011000" in list(df["site_id"])
     assert "stream gauge" in list(df["site_type"])
     assert "groundwater well" in list(df["site_type"])
@@ -1078,7 +1078,7 @@ def test_get_variables_lat_lon_dict():
     df = point.get_site_variables(query_parameters)
 
     # Bounds are flexible for if more sites are added
-    assert (len(df) >= 36) & (len(df) <= 65)
+    assert (len(df) >= 36) & (len(df) <= 85)
     assert "01011000" in list(df["site_id"])
     assert "stream gauge" in list(df["site_type"])
     assert "groundwater well" in list(df["site_type"])


### PR DESCRIPTION
This Pull Request adds some additional variables to the DataFrame returned from the `point.get_site_variables()` function. The additional variables include the dataset name, temporal resolution, aggregation, and variable name as they would be input as parameters into the `get_point_data()` or `get_point_metadata()` functions. The conus1 and conus2 grid mappings are also merged on. 

These updates are being made to support the "get observations" step in the HydroGEN project model evaluation framework development.