### PR TITLE
truncate instead of round in to_ij

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.1.14"
+version = "1.1.15"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/grid.py
+++ b/src/hf_hydrodata/grid.py
@@ -172,8 +172,8 @@ def to_ij(grid: str, *args) -> List[int]:
         (i, j) = hf.to_ij("conus1", 31.759219, -115.902573)
         ij_bounds = hf.to_ij("conus1", *[31.651836, -115.982367, 31.759219, -115.902573])
     """
-
-    result = [round(v) for v in from_latlon(grid, *args)]
+    epsilon = 0.001  # Account for floating point round off when truncating to int
+    result = [int(v+epsilon) for v in from_latlon(grid, *args)]
     return result
 
 


### PR DESCRIPTION
Change to_ij() method to truncate instead of round.
Add an epsilon to the floating point number before truncating, this allows converting from int to float and back to in to get the same value again, but still the truncate instead of round is more correct.
