### PR TITLE
fix problem with limit of files passed to read_pfb_sequence

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.1.14"
+version = "1.1.15"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -1763,5 +1763,22 @@ def test_flow_direction():
     assert data[0, 1] == 4.0
 
 
+def test_smap_current_conditions():
+    """Test a bug that happened when trying to read too many pfb files in a single call to get_gridded_data"""
+    x = 2387
+    y = 1673
+    st_dt = "2023-08-01"
+    options = {
+        "data_catalog_entry_id": "213",
+        "start_time": st_dt,
+        "end_time": "2024-02-01",
+        "x": x,
+        "y": y,
+    }
+    data = hf.get_gridded_data(options)
+    # This used to fail before fixing a bug to call read_pfb_sequence with a limited block size
+    assert (data[62] - 0.3409) <= 0.001, "Data for long block length not read properly"
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Fix a problem in get_gridded_data that uses parflow read_pfb_sequence() to read pfb files.
It turns out that this does not work if the number of files passed in the sequence it too large (> 100 or so).
It returned, but not always with the correct data so this was messing up line charts in hydrogen point observations.
This is fixed in this PR by reading blocks of files with read_pfb_sequence and appending together the results.
There is a unit test to replicate the old problem that is fixed by this PR.
