### PR TITLE
fix get_gridded_files for .nc files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.1.17"
+version = "1.1.18"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -506,7 +506,7 @@ def get_gridded_files(
         # The .nc file will have a time dimension with coordinates of the water year containing the data in the file.
         # For the example above the time dimension would be between 2005-10-1 to 2006-09-30 
         #    with only 3 days of data downloaded and stored in the file.
-        # The .nc file with have x dimension 100 and y dimensions 50 defined by the grid_bounds.
+        # The .nc file will have x dimension 100 and y dimensions 50 defined by the grid_bounds.
 
         # To download data into a GeoTiff file specify a filename_template ending with .tiff
         hf.get_gridded_files(
@@ -518,7 +518,7 @@ def get_gridded_files(
         #   NLDAS2.precipitation.tiff
         #   NLDAS2.air_temp.tiff
         # Only the first hour of the period "2005-10-01 00:00:00" is used to create the files.
-        # The files will contain projection information suitable to view with GIS.
+        # The tiff files will contain projection information suitable to view with GIS.
 
     For long downloads if the function execution is aborted before completion it can be restarted and will continue where it left off by skipping
     files that already exist. To re-download data, remember to delete previously created files first.

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -587,14 +587,6 @@ def get_gridded_files(
         variables = [entry["variable"]]
 
     # Start threads to download data
-    state = _FileDownloadState(
-        options,
-        filename_template,
-        temporal_resolution,
-        start_time,
-        end_time,
-        verbose,
-    )
     if temporal_resolution in ["daily", "hourly"]:
         delta = datetime.timedelta(days=1)
     elif temporal_resolution == "monthly":
@@ -610,6 +602,16 @@ def get_gridded_files(
     dask_items = []
     file_time = start_time
     time_index = 0
+    state = _FileDownloadState(
+        options,
+        filename_template,
+        temporal_resolution,
+        start_time,
+        end_time,
+        verbose,
+    )
+    state.generate_time_coords(file_time)
+
     while file_time < end_time:
         options = dict(options)
         options["start_time"] = file_time
@@ -637,10 +639,11 @@ def get_gridded_files(
                         end_time,
                         verbose,
                     )
+                    state.generate_time_coords(file_time)
                     dask_items = []
                 dask_items.append(
                     dask.delayed(_load_gridded_file_entry)(
-                        state, entry, options_copy, file_time, time_index
+                        state, entry, options_copy, file_time
                     )
                 )
             last_file_name = file_name
@@ -702,8 +705,7 @@ def _load_gridded_file_entry(
     state,
     entry: ModelTableRow,
     options: dict,
-    file_time: datetime.datetime,
-    time_index: int,
+    file_time: datetime.datetime
 ):
     """
     Get data from within a dask deferred thread.
@@ -716,14 +718,12 @@ def _load_gridded_file_entry(
     file_name = _substitute_datapath(
         state.filename_template, entry, options, file_time, state.start_time
     )
-    print(f"Create file {file_name}")
+
     if os.path.exists(file_name):
         # File already exists, so just skip this
         return
 
-    print("Call get gridded data")
     data = get_gridded_data(options)
-    print(data.shape)
 
     if state.filename_template.endswith(".pfb"):
         # Creating pfb file for get_gridded_files
@@ -733,7 +733,7 @@ def _load_gridded_file_entry(
         _create_gridded_files_geotiff(data, state, entry, options, file_time)
     elif state.filename_template.endswith(".nc"):
         # Creating NetCDF file, put the data from the API response into the data object from state
-        _create_gridded_files_netcdf(data, state, entry, time_index, file_time)
+        _create_gridded_files_netcdf(data, state, entry, file_time)
 
     if state.verbose:
         if entry["temporal_resolution"] in ["daily", "hourly"]:
@@ -744,27 +744,26 @@ def _load_gridded_file_entry(
                 (state.end_time - state.start_time).days if state.start_time else 0
             )
             variable = options.get("variable")
-            print(f"Downloaded {variable} for day {file_daynum} of {num_days}")
+            (wy, _) = _get_water_year(file_time)
+            print(f"Downloaded day {file_daynum} of {variable} in water year {wy}")
         else:
             print(f"Downloaded {file_name}")
 
 
 def _create_gridded_files_netcdf(
-    data: np.ndarray, state, entry, time_index, file_time: datetime.datetime
+    data: np.ndarray, state, entry, file_time: datetime.datetime
 ):
+    (wy, wy_start_time) = _get_water_year(file_time)
+    days_in_year = 366 if int(wy) % 4 == 0 else 365
     if state.temporal_resolution == "daily":
-        t_num = (file_time - state.start_time).days if state.start_time else 0
-        t_shape = (state.end_time - state.start_time).days if state.start_time else 0
+        t_num = (file_time - wy_start_time).days
+        t_shape = days_in_year
     elif state.temporal_resolution == "hourly":
-        t_num = (file_time - state.start_time).days * 24 if state.start_time else 0
-        t_shape = (
-            (state.end_time - state.start_time).days * 24 if state.start_time else 0
-        )
+        t_shape = days_in_year * 24
+        t_num = (file_time - wy_start_time).days * 24
     elif state.temporal_resolution == "monthly":
-        t_num = time_index
-        t_shape = rrule.rrule(
-            rrule.MONTHLY, dtstart=state.start_time, until=state.end_time
-        ).count()
+        t_shape = 12
+        t_num = (file_time - wy_start_time).months
     elif state.temporal_resolution == "static":
         t_num = 0
         t_shape = 1
@@ -796,6 +795,7 @@ def _create_gridded_files_netcdf(
             else:
                 raise ValueError("Bad shape of data returned from API.")
             nc_data = np.zeros(data_shape)
+
             state.data_map[dataset_var] = nc_data
             state.dims_map[dataset_var] = dims
 
@@ -1989,7 +1989,9 @@ def _read_and_filter_netcdf_files(
     if len(paths) == 0:
         raise ValueError(f"No file path found for {entry['id']}")
     if len(paths) > 1:
-        raise ValueError(f"Request attempts to return too much data. Try to limit dates to a single water year per call to get_gridded_data() or try to use get_gridded_files() instead.")
+        raise ValueError(
+            "Request attempts to return too much data. Try to limit dates to a single water year per call to get_gridded_data() or try to use get_gridded_files() instead."
+        )
     file_path = paths[0]
     if file_path.endswith("*"):
         # Data path contins a wild card so use that to find the filename
@@ -2759,25 +2761,28 @@ class _FileDownloadState:
         self.filename_template = filename_template
         self.verbose = verbose
         self.threads = int(options.get("threads")) if options.get("threads") else 10
-        self.generate_time_coords()
 
-    def generate_time_coords(self):
+    def generate_time_coords(self, file_time):
         """Generate the self.time_coords with the time values of the time coordinate."""
+
+        (wy, wy_start_time) = _get_water_year(file_time)
+        days_in_year = 366 if int(wy) % 4 == 0 else 365
+
         if self.temporal_resolution == "daily":
             self.time_coords = []
-            t = self.start_time
-            for _ in range(0, (self.end_time - self.start_time).days):
+            t = wy_start_time
+            for _ in range(0, days_in_year):
                 self.time_coords.append(t)
                 t = t + datetime.timedelta(days=1)
         elif self.temporal_resolution == "hourly":
             self.time_coords = []
-            t = self.start_time
-            for _ in range(0, (self.end_time - self.start_time).days * 24):
+            t = wy_start_time
+            for _ in range(0, days_in_year * 24):
                 self.time_coords.append(t)
                 t = t + datetime.timedelta(hours=1)
         elif self.temporal_resolution == "monthly":
             self.time_coords = []
-            t = self.start_time
-            while t < self.end_time:
+            t = wy_start_time
+            for _ in range(0, 1):
                 self.time_coords.append(t)
                 t = t + relativedelta(months=1)

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -503,7 +503,9 @@ def get_gridded_files(
         # The above function call will create a netcdf file named:
         #    NLDAS2_WY2006.nc
         # The .nc file will have two variables: precipitation and air_temp.
-        # The .nc file will have a time dimension with coordinates between 2005-10-1 to 2005-10-04.
+        # The .nc file will have a time dimension with coordinates of the water year containing the data in the file.
+        # For the example above the time dimension would be between 2005-10-1 to 2006-09-30 
+        #    with only 3 days of data downloaded and stored in the file.
         # The .nc file with have x dimension 100 and y dimensions 50 defined by the grid_bounds.
 
         # To download data into a GeoTiff file specify a filename_template ending with .tiff

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -1401,9 +1401,9 @@ def test_get_gridded_files_netcdf():
         ds = xr.open_dataset("NLDAS2.2006.nc")
         assert len(ds.keys()) == 2
         ground_heat = ds["eflx_soil_grnd"]
-        assert ground_heat.shape == (120, 10, 4)
+        assert ground_heat.shape == (8760, 10, 4)
         pressure_head = ds["Press"]
-        assert pressure_head.shape == (120, 5, 10, 4)
+        assert pressure_head.shape == (8760, 5, 10, 4)
         lat_coord = ds["latitude"]
         assert lat_coord.shape == (10, 4)
 
@@ -1479,15 +1479,15 @@ def test_multiple_aggregations():
         assert os.path.exists("foo.nc")
         ds = xr.open_dataset("foo.nc")
         da = ds["APCP"]
-        assert da.shape == (2, 2, 2)
+        assert da.shape == (365, 2, 2)
         da = ds["DSWR"]
-        assert da.shape == (2, 2, 2)
+        assert da.shape == (365, 2, 2)
         da = ds["Temp_mean"]
-        assert da.shape == (2, 2, 2)
+        assert da.shape == (365, 2, 2)
         da = ds["Temp_min"]
-        assert da.shape == (2, 2, 2)
+        assert da.shape == (365, 2, 2)
         da = ds["Temp_max"]
-        assert da.shape == (2, 2, 2)
+        assert da.shape == (365, 2, 2)
     os.chdir(cd)
 
 


### PR DESCRIPTION
Change the way NetCDF files are created by get_gridded_files() to match what Nick expected when using it.
The new strategy populates the variables in the NetCDF file with a single water year of 365/366 day entries for daily files
or 365/366 * 24 hour entries for hourly or 12 month entries for month.

Each time dimension in the NetCDF file would always start at the beginning of the water year and populate with data requested in the query. It also fills in time coordinate times in the NetCDF file, but with this strategy the user would know the time based on the dimension index.