### PR TITLE
add retry logic in gridded data API call

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.2.4"
+version = "1.2.5"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -1827,7 +1827,13 @@ def _read_and_filter_pfb_files(
             else len(paths)
         )
         path_block = paths[block_start:block_end]
+        print("Start READ_PFB_SEQUENCE")
+        print(len(path_block))
+        print(boundary_constraints)
+        st = time.time()
         data = read_pfb_sequence(path_block, boundary_constraints)
+        duration = time.time() - st
+        print(f"Duration = {duration}")
         if final_data is None:
             # This is the first block
             final_data = data

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -1117,7 +1117,7 @@ def _write_file_from_api(filepath, options):
 
     try:
         headers = _get_api_headers()
-        response = requests.get(datafile_url, headers=headers, timeout=1200)
+        response = requests.get(datafile_url, headers=headers, timeout=4000)
         if response.status_code != 200:
             if response.status_code == 400:
                 content = response.content.decode()

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -1827,13 +1827,7 @@ def _read_and_filter_pfb_files(
             else len(paths)
         )
         path_block = paths[block_start:block_end]
-        print("Start READ_PFB_SEQUENCE")
-        print(len(path_block))
-        print(boundary_constraints)
-        st = time.time()
         data = read_pfb_sequence(path_block, boundary_constraints)
-        duration = time.time() - st
-        print(f"Duration = {duration}")
         if final_data is None:
             # This is the first block
             final_data = data

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -1638,17 +1638,20 @@ def _get_ndarray_from_api(entry, options):
 
         try:
             headers = _get_api_headers()
-            response = requests.get(gridded_data_url, headers=headers, timeout=1200)
+            response = requests.get(gridded_data_url, headers=headers, timeout=4000)
+            if response.status_code in [500, 502]:
+                # Retry because of timeout error
+                response = requests.get(gridded_data_url, headers=headers, timeout=4000)
+            if response.status_code == 400:
+                content = response.content.decode()
+                response_json = json.loads(content)
+                message = response_json.get("message")
+                raise ValueError(message)
+            if response.status_code in [500, 502]:
+                raise ValueError(
+                    "Timeout error from server. Try again later or try to reduce the size of data in the API request using time or space filters."
+                )
             if response.status_code != 200:
-                if response.status_code == 400:
-                    content = response.content.decode()
-                    response_json = json.loads(content)
-                    message = response_json.get("message")
-                    raise ValueError(message)
-                if response.status_code == 502:
-                    raise ValueError(
-                        "Timeout error from server. Try again later or try to reduce the size of data in the API request using time or space filters."
-                    )
                 raise ValueError(
                     f"The  {gridded_data_url} returned error code {response.status_code}."
                 )

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -1850,6 +1850,22 @@ def test_timeout_retry_logic(mocker):
         hf.get_gridded_data(options)
     assert requests.get.call_count == 2
 
+def test_wateryear_one_point():
+    """Test request for CW3E dataset water year for one point."""
+    options = {
+        "dataset": "CW3E",
+        "variable": "air_temp",
+        "temporal_resolution": "hourly",
+        "start_time": "2006-10-01",
+        "end_time": "2007-10-01",
+        "grid": "conus2",
+        "grid_bounds": [1000, 1000, 1001, 1001],
+    }
+
+    # This call makes 4 calls (blocks of 100 files) cached 0.97, .15, .14, .09 = 1.1 secibds
+    # When not cached 9.43, 8.68, 8.71, 6 = 33 seconds
+    data = hf.get_gridded_data(options)
+    assert data.shape == (8760, 1, 1)
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -2,7 +2,7 @@
 Unit test for the gridded module.
 """
 
-# pylint: disable=C0301,C0103,W0632,W0702,W0101,C0302,W0105,E0401,C0413,R0903,W0613,R0912,W0212
+# pylint: disable=C0301,C0103,W0632,W0702,W0101,C0302,W0105,E0401,C0413,R0903,W0613,R0912,W0212,R1714,E1101
 import sys
 import os
 import datetime
@@ -14,6 +14,7 @@ import numpy as np
 import pytest
 import pytz
 import rioxarray
+import requests
 
 from parflow import read_pfb_sequence
 
@@ -1816,6 +1817,38 @@ def test_cw3e_version():
 
     cw3e_default = hf.get_gridded_data(options)
     np.testing.assert_array_equal(cw3e_default, cw3e_version09)
+
+
+def test_timeout_retry_logic(mocker):
+    """Test that API retry logic only retries once."""
+    options = {
+        "dataset": "CW3E",
+        "variable": "air_temp",
+        "temporal_resolution": "hourly",
+        "start_time": "2002-10-01",
+        "end_time": "2002-10-02",
+        "grid": "conus2",
+        "grid_bounds": [1000, 1000, 1002, 1002],
+    }
+
+    def mock_api_requests_get(url, headers, timeout):
+        response = MockResponse()
+        if requests.get.call_count == 1:
+            response.status_code = 500
+        elif requests.get.call_count == 2:
+            response.status_code = 500
+        else:
+            assert False, "Called too many times"
+        return response
+
+    mocker.patch(
+        "requests.get",
+        side_effect=mock_api_requests_get,
+    )
+    hf.gridded.HYDRODATA = "/foo"
+    with pytest.raises(ValueError):
+        hf.get_gridded_data(options)
+    assert requests.get.call_count == 2
 
 
 if __name__ == "__main__":

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -1849,6 +1849,7 @@ def test_timeout_retry_logic(mocker):
     with pytest.raises(ValueError):
         hf.get_gridded_data(options)
     assert requests.get.call_count == 2
+    hf.gridded.HYDRODATA = "/hydrodata"
 
 def test_wateryear_one_point():
     """Test request for CW3E dataset water year for one point."""


### PR DESCRIPTION
Add retry logic if hf_hydrodata when API call to get data returns a 500 error.
This only does one retry in case it is a real error, but it the error was a timeout error because slow GPFS with files not cached the second retry is usually very fast because the files are then cached.

I will add a test case to the gridded_tests/test_gridded.py file in the hydroframe-ml/perfm_testing repo since this scenario cannot be tested as a unit test because it is a performance problem that only happens when running remotely. 