### PR TITLE
allow readthedocs build to read data catalog

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.3"
+version = "1.3.4"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/data_catalog.py
+++ b/src/hf_hydrodata/data_catalog.py
@@ -9,8 +9,7 @@ from typing import List
 import threading
 from hf_hydrodata.data_model_access import (
     ModelTableRow,
-    load_data_model,
-    _get_api_headers,
+    load_data_model
 )
 
 HYDRODATA = "/hydrodata"

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -375,6 +375,7 @@ def get_gridded_files(
 
     The extension of the filename_template determines the file format. Only extensions .pfb, .tiff, or .nc are supported at this time.
     For tiff files only the first time period of the selected data is saved in the file since a tiff is 2D.
+    For .nc files the files are always created one file per water year so the filename_template should contain {wy} in the name.
 
     The default filename_template saves data as pfb files:
         * hourly:   {dataset}.{dataset_var}.{hour_start:06d}_to_{hour_end:06d}.pfb


### PR DESCRIPTION
Modify so that we can call the data catalog URL without an API pin to get the public version of the data catalog.
This was required so the read-the-docs generate could get the data catalog information for public documentation.
This API pin is now optional for the call to get data catalog information, but still required for calls to get data.