### PR TITLE
pass schema when getting gridded_data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.4"
+version = "1.3.5"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -954,6 +954,8 @@ def _construct_string_from_options(qparam_values):
     string_parts = [
         f"{name}={value}" for name, value in qparam_values.items() if value is not None
     ]
+    schema = os.getenv("DC_SCHEMA", "public")
+    string_parts.append(f"schema={schema}")
     result_string = "&".join(string_parts)
     return result_string
 
@@ -1547,6 +1549,7 @@ def _get_gridded_data_from_api(options):
         if options.get("period") and not options.get("temporal_resolution"):
             options["period"] = options["temporal_resolution"]
         options = _convert_json_to_strings(options)
+        options["schema"] = os.getenv("DC_SCHEMA", "public")
         options_list = [
             f"{name}={value}" for name, value in options.items() if value is not None
         ]


### PR DESCRIPTION
Update to pass schema to URL when calling get_gridded_data().
Before it passed schema in the API call to get the data catalog, but not for the get_gridded_data() URL.
This is necessary so the unit tests all use the development schema when running tests.
