### PR TITLE
Use data catalog in point module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.9"
+version = "1.3.10"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.8"
+version = "1.3.9"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -244,11 +244,6 @@ def get_paths(*args, **kwargs) -> List[str]:
         else entry.get("period")
     )
 
-    # For point module filtering, we want the directory path, not the full file path
-    if "for_point_module" in options and options["for_point_module"] is not None:
-        if path:
-            return [("/").join(path.split("/")[:-1])]
-
     if path:
         # Get option parameters
         start_time_value = _parse_time(options.get("start_time"))

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -243,6 +243,12 @@ def get_paths(*args, **kwargs) -> List[str]:
         if entry.get("temporal_resolution")
         else entry.get("period")
     )
+
+    # For point module filtering, we want the directory path, not the full file path
+    if "for_point_module" in options and options["for_point_module"] is not None:
+        if path:
+            return [("/").join(path.split("/")[:-1])]
+
     if path:
         # Get option parameters
         start_time_value = _parse_time(options.get("start_time"))
@@ -355,9 +361,12 @@ def get_file_path(entry, *args, **kwargs) -> str:
     result = paths[0]
     return result
 
+
 def get_numpy(*args, **kwargs):
     """Deprecated. Return an error."""
-    raise ValueError("The get_numpy() function is not supported anymore. Use get_gridded_data instead.")
+    raise ValueError(
+        "The get_numpy() function is not supported anymore. Use get_gridded_data instead."
+    )
 
 
 def get_gridded_files(
@@ -558,7 +567,9 @@ def get_gridded_files(
             options["variable"] = variable
             options_copy = dict(options)
             aggregation_entries = _get_aggregation_entries(options)
-            aggregation_types = [agg_entry.get("aggregation") for agg_entry in aggregation_entries]
+            aggregation_types = [
+                agg_entry.get("aggregation") for agg_entry in aggregation_entries
+            ]
             if "min" not in aggregation_types and "max" not in aggregation_types:
                 # No point looping through aggregation types if max or main are not options
                 entry = dc.get_catalog_entry(options)
@@ -1637,7 +1648,8 @@ def _adjust_dimensions(data: np.ndarray, entry: ModelTableRow) -> np.ndarray:
     period = period if period in ["hourly", "daily", "monthly", "weekly"] else "static"
     has_z = entry.get("has_z") is not None and entry.get("has_z").lower() == "true"
     has_ensemble = (
-        entry.get("has_ensemble") is not None and entry.get("has_ensemble").lower() == "true"
+        entry.get("has_ensemble") is not None
+        and entry.get("has_ensemble").lower() == "true"
     )
     existing_shape = data.shape
     new_shape = existing_shape
@@ -1734,7 +1746,7 @@ def _read_and_filter_pfb_files(
     boundary_constraints = _add_pfb_time_constraint(
         boundary_constraints, entry, start_time_value, end_time_value
     )
-    
+
     # The read_pfb_sequence method has a limit to how many paths it can read
     # if the number of paths is more than the limit call read_pfb_sequence in blocks
     # then append together the blocks to return the correct result
@@ -2189,8 +2201,7 @@ def _get_pfb_boundary_constraints(grid: str, options: dict) -> dict:
         }
         if z is not None:
             z = int(z)
-            result["z"] = {"start": z, "stop": z+1}
-
+            result["z"] = {"start": z, "stop": z + 1}
 
     return result
 

--- a/tests/hf_hydrodata/test_point.py
+++ b/tests/hf_hydrodata/test_point.py
@@ -1821,5 +1821,26 @@ def test_huc_list():
     assert df.shape[1] == 23
 
 
+def test_depth_level_provided_not_sm():
+    """Test for if depth_level parameter is provided by the user
+    for a variable other than soil moisture."""
+    with pytest.raises(Exception) as exc:
+        point.get_point_data(
+            dataset="usgs_nwis",
+            variable="streamflow",
+            temporal_resolution="daily",
+            aggregation="mean",
+            date_start="2002-01-01",
+            date_end="2002-01-05",
+            latitude_range=(47, 50),
+            longitude_range=(-75, -50),
+            depth_level=2,
+        )
+    assert (
+        str(exc.value)
+        == "Parameter depth_level is only supported when variable=='soil_moisture'."
+    )
+
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
This PR removes hard-coding done in the point module in favor of utilizing `hf.get_catalog_entry` to get information on file paths and internal file variable names. All of our current tests should continue to pass; this is changing how files/data are found in the point module but is not adding or changing any user-facing features.

Some small linting in `gridded.py` got carried over as well.