### PR TITLE
Do not mask vegm with get_gridded_data()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.8"
+version = "1.3.9"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/data_model_access.py
+++ b/src/hf_hydrodata/data_model_access.py
@@ -218,6 +218,9 @@ def _get_api_headers(required=True) -> dict:
         url_security = f"{HYDRODATA_URL}/api/api_pins?pin={pin}&email={email}"
         response = requests.get(url_security, timeout=1200)
         if not response.status_code == 200:
+            if not required:
+                # The PIN is not required so it is ok that the API request returned an error.
+                return {}
             raise ValueError(
                 f"No registered PIN for '{email}' (expired?). Re-register a pin with https://hydrogen.princeton.edu/pin . Signup with https://hydrogen.princeton.edu/signup. Register the pin with python by executing 'hf_hydrodata.register_api_pin()'."
             )

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -1251,8 +1251,11 @@ def _apply_mask(data, entry, options):
     The second option masks only against ocean and outer HUC bounds. The first option masks with internal HUC boundaries.
     """
 
-    if options.get("dataset") == "huc_mapping" or options.get("variable") == "clm_run":
-        # Do not mask mask
+    if options.get("dataset") == "huc_mapping":
+        # Do not mask mask the huc_mapping dataset that is used for masking
+        return data        
+    if options.get("variable") == "clm_run":
+        # Do not mask any entry with the clm_run variable that contains vegm data
         return data
     grid = entry.get("grid")
     if grid not in ["conus1", "conus2"]:

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -1252,7 +1252,7 @@ def _apply_mask(data, entry, options):
     """
 
     if options.get("dataset") == "huc_mapping":
-        # Do not mask mask the huc_mapping dataset that is used for masking
+        # Do not mask any entry from the huc_mapping dataset that is used for masking
         return data        
     if options.get("variable") == "clm_run":
         # Do not mask any entry with the clm_run variable that contains vegm data

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -1251,8 +1251,8 @@ def _apply_mask(data, entry, options):
     The second option masks only against ocean and outer HUC bounds. The first option masks with internal HUC boundaries.
     """
 
-    if options.get("dataset") == "huc_mapping":
-        # Do not mask the mask
+    if options.get("dataset") == "huc_mapping" or options.get("variable") == "clm_run":
+        # Do not mask mask
         return data
     grid = entry.get("grid")
     if grid not in ["conus1", "conus2"]:

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -1845,7 +1845,8 @@ def test_pf_flow_barrier():
 def test_get_pfb_vegm_with_default_masking():
     """Test that get_gridded_data() does not mask vegm files."""
 
-    bounds = [200, 200, 202, 202]
+    # Test a point on coast line
+    bounds = [0, 0, 2, 2]
     options = {
         "dataset": "conus2_domain",
         "variable": "clm_run",
@@ -1855,10 +1856,24 @@ def test_get_pfb_vegm_with_default_masking():
     data = hf.get_gridded_data(options)
     assert data.shape == (23, 2, 2)
     assert data[4, 0, 0] == 4
-    assert pytest.approx(data[0, 0, 0], 0.0001) == 24.4858
+    assert pytest.approx(data[0, 0, 0], 0.0001) == 22.368969
     assert pytest.approx(data[2, 0, 0], 0.01) == .16
     assert pytest.approx(data[3, 0, 0], 0.01) == .19
 
+    # Test a point in a Great Lake
+    bounds = [2977, 2199, 2978, 2200]
+    options = {
+        "dataset": "conus2_domain",
+        "variable": "clm_run",
+        "file_type": "pfb",
+        "grid_bounds": bounds,
+    }
+    data = hf.get_gridded_data(options)
+    assert data.shape == (23, 1, 1)
+    assert data[4, 0, 0] == 4
+    assert pytest.approx(data[0, 0, 0], 0.0001) == 44.481031
+    assert pytest.approx(data[2, 0, 0], 0.01) == .04
+    assert pytest.approx(data[3, 0, 0], 0.01) == .19
 
 def test_get_pfb_vegm_for_zvalue():
     """Test get vegm values using pfb file type and z value."""

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -1842,6 +1842,24 @@ def test_pf_flow_barrier():
     assert data[3, 3, 4] == 0.001
 
 
+def test_get_pfb_vegm_with_default_masking():
+    """Test that get_gridded_data() does not mask vegm files."""
+
+    bounds = [200, 200, 202, 202]
+    options = {
+        "dataset": "conus2_domain",
+        "variable": "clm_run",
+        "file_type": "pfb",
+        "grid_bounds": bounds,
+    }
+    data = hf.get_gridded_data(options)
+    assert data.shape == (23, 2, 2)
+    assert data[4, 0, 0] == 4
+    assert pytest.approx(data[0, 0, 0], 0.0001) == 24.4858
+    assert pytest.approx(data[2, 0, 0], 0.01) == .16
+    assert pytest.approx(data[3, 0, 0], 0.01) == .19
+
+
 def test_get_pfb_vegm_for_zvalue():
     """Test get vegm values using pfb file type and z value."""
     bounds = [200, 200, 202, 202]
@@ -1867,7 +1885,6 @@ def test_get_pfb_vegm_for_zvalue():
     }
     data = hf.get_gridded_data(options)
     assert data.shape == (23, 2, 2)
-
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Change _apply_mask function from get_gridded_data() so that it does not mask the value of vegm files.
The vegm file is returned by the variable "clm_run".
This fixes a problem in subset tools that subsets the vegm file and writes it to a file for use by parflow.
Since the file used by parflow is a .dat text file the NaNs created by the mask create an error when trying to save.
