### PR TITLE
fix get_gridded_files for temporal_resolution static

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.11"
+version = "1.3.12"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -466,6 +466,11 @@ def get_gridded_files(
         options["temporal_resolution"] = options.get("period")
     temporal_resolution = options.get("temporal_resolution")
     temporal_resolution = (
+        "static"
+        if temporal_resolution is None or temporal_resolution in ["", "-", "static"]
+        else temporal_resolution
+    )
+    temporal_resolution = (
         _get_temporal_resolution_from_catalog(options)
         if temporal_resolution is None
         else temporal_resolution
@@ -1259,7 +1264,7 @@ def _apply_mask(data, entry, options):
 
     if options.get("dataset") == "huc_mapping":
         # Do not mask any entry from the huc_mapping dataset that is used for masking
-        return data        
+        return data
     if options.get("variable") == "clm_run":
         # Do not mask any entry with the clm_run variable that contains vegm data
         return data

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -1180,7 +1180,6 @@ def test_get_datasets():
 
     options = {"variable": "air_temp", "grid": "conus1"}
     datasets = hf.get_datasets(options)
-    print(datasets)
     assert len(datasets) >= 4
     assert datasets[0] == "NLDAS2"
 
@@ -1379,6 +1378,48 @@ def test_get_gridded_files_tiff():
         )
         assert os.path.exists("conus1_baseline_mod.ground_heat.tiff")
         luc = rioxarray.open_rasterio("conus1_baseline_mod.ground_heat.tiff")
+        assert 'standard_parallel_1",33' in str(luc.rio.crs)
+    os.chdir(cd)
+
+
+def test_get_huc_conus_2_gridded_files_tiff():
+    """Unit test for get_gridded_files to get conus2 huc_map as tiff file."""
+
+    cd = os.getcwd()
+    with tempfile.TemporaryDirectory() as tempdirname:
+        os.chdir(tempdirname)
+        options = {
+            "dataset": "huc_mapping",
+            "variable": "huc_map",
+            "grid": "conus2",
+            "level": "2",
+        }
+        output_file = "foo.tiff"
+        assert not os.path.exists(output_file)
+        gr.get_gridded_files(options, filename_template=output_file)
+        assert os.path.exists(output_file)
+        luc = rioxarray.open_rasterio(output_file)
+        assert 'standard_parallel_1",30' in str(luc.rio.crs)
+    os.chdir(cd)
+
+
+def test_get_huc_conus_1_gridded_files_tiff():
+    """Unit test for get_gridded_files to get conus1 huc_map as tiff file."""
+
+    cd = os.getcwd()
+    with tempfile.TemporaryDirectory() as tempdirname:
+        os.chdir(tempdirname)
+        options = {
+            "dataset": "huc_mapping",
+            "variable": "huc_map",
+            "grid": "conus1",
+            "level": "2",
+        }
+        output_file = "foo.tiff"
+        assert not os.path.exists(output_file)
+        gr.get_gridded_files(options, filename_template=output_file)
+        assert os.path.exists(output_file)
+        luc = rioxarray.open_rasterio(output_file)
         assert 'standard_parallel_1",33' in str(luc.rio.crs)
     os.chdir(cd)
 
@@ -1857,8 +1898,8 @@ def test_get_pfb_vegm_with_default_masking():
     assert data.shape == (23, 2, 2)
     assert data[4, 0, 0] == 4
     assert pytest.approx(data[0, 0, 0], 0.0001) == 22.368969
-    assert pytest.approx(data[2, 0, 0], 0.01) == .16
-    assert pytest.approx(data[3, 0, 0], 0.01) == .19
+    assert pytest.approx(data[2, 0, 0], 0.01) == 0.16
+    assert pytest.approx(data[3, 0, 0], 0.01) == 0.19
 
     # Test a point in a Great Lake
     bounds = [2977, 2199, 2978, 2200]
@@ -1872,8 +1913,9 @@ def test_get_pfb_vegm_with_default_masking():
     assert data.shape == (23, 1, 1)
     assert data[4, 0, 0] == 4
     assert pytest.approx(data[0, 0, 0], 0.0001) == 44.481031
-    assert pytest.approx(data[2, 0, 0], 0.01) == .04
-    assert pytest.approx(data[3, 0, 0], 0.01) == .19
+    assert pytest.approx(data[2, 0, 0], 0.01) == 0.04
+    assert pytest.approx(data[3, 0, 0], 0.01) == 0.19
+
 
 def test_get_pfb_vegm_for_zvalue():
     """Test get vegm values using pfb file type and z value."""
@@ -1900,6 +1942,7 @@ def test_get_pfb_vegm_for_zvalue():
     }
     data = hf.get_gridded_data(options)
     assert data.shape == (23, 2, 2)
+
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Change the get_gridded_files function to support entries that have a temporal resolution of "", "-", or "static".
Fix the code and add unit tests to check this scenario.