### PR TITLE
fix error handling of get_gridded_files()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.13"
+version = "1.3.14"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -13,10 +13,10 @@ import json
 import shutil
 import tempfile
 import threading
+import importlib.metadata
 import dask
 import requests
 import pyproj
-import importlib.metadata
 from dateutil import rrule
 from dateutil.relativedelta import relativedelta
 import numpy as np
@@ -1546,6 +1546,9 @@ def _convert_json_to_strings(options):
         if key == "time_values":
             if not isinstance(value, str):
                 options[key] = json.dumps(value)
+
+    hf_hydrodata_version = importlib.metadata.version("hf_hydrodata")
+    options["hf_version"] = hf_hydrodata_version
 
     return options
 

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -532,8 +532,8 @@ def get_gridded_files(
         if entry is None:
             raise ValueError("No data catalog entry found for options.")
         variables = [entry.get("variable")]
-    if  isinstance(variables, str):
-        raise ValueError("The variables parameters must be a list, not a string")
+    if isinstance(variables, str):
+        variables = [variables]
 
     # Start threads to download data
     if temporal_resolution in ["daily", "hourly"]:

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -16,6 +16,7 @@ import threading
 import dask
 import requests
 import pyproj
+import importlib.metadata
 from dateutil import rrule
 from dateutil.relativedelta import relativedelta
 import numpy as np
@@ -970,6 +971,8 @@ def _construct_string_from_options(qparam_values):
     ]
     schema = os.getenv("DC_SCHEMA", "public")
     string_parts.append(f"schema={schema}")
+    hf_hydrodata_version = importlib.metadata.version("hf_hydrodata")
+    string_parts.append(f"hf_version={hf_hydrodata_version}")
     result_string = "&".join(string_parts)
     return result_string
 

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -394,7 +394,7 @@ def get_gridded_files(
     Args:
         options:            A dict containing data filters to be passed to get_gridded_data().
         filename_template:  A template used to create the file name(s) to store the data downloaded.
-        variables:          A list of variable names to download. If provided, this overwrites the variable defined in options dict.
+        variables:          A list of variable names (or a single name as a string) to download. If provided, this overwrites the variable defined in options dict.
         verbose:            If True, prints progress of downloaded data while downloading.
     Raises:
         ValueError:  If an error occurs while downloading and creating files.

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -532,6 +532,8 @@ def get_gridded_files(
         if entry is None:
             raise ValueError("No data catalog entry found for options.")
         variables = [entry.get("variable")]
+    if  isinstance(variables, str):
+        raise ValueError("The variables parameters must be a list, not a string")
 
     # Start threads to download data
     if temporal_resolution in ["daily", "hourly"]:
@@ -546,6 +548,7 @@ def get_gridded_files(
         )
 
     last_file_name = None
+    file_name = None
     dask_items = []
     file_time = start_time
     time_index = 0

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -1951,6 +1951,7 @@ def test_temporal_resolution_static():
     with tempfile.TemporaryDirectory() as tempdirname:
         os.chdir(tempdirname)
 
+        # Check with temporal_resolution:static even though data catalog has blank temporal resolution
         options = {
             "dataset": "conus2_domain",
             "variable": "mask",
@@ -1968,7 +1969,7 @@ def test_temporal_resolution_static():
         data = parflow.read_pfb("foo_conus2_domain_mask.pfb")
         assert data.shape == (1, 852, 586)
 
-        # Verify
+        # Test error message if the variable parameter is passed as a string instead of a list.
         with pytest.raises(ValueError, match="must be a list, not a string"):
             variables = "mask"
             hf.get_gridded_files(

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -1969,7 +1969,7 @@ def test_temporal_resolution_static():
         data = parflow.read_pfb("foo_conus2_domain_mask.pfb")
         assert data.shape == (1, 852, 586)
 
-        # Test error message if the variable parameter is passed as a string instead of a list.
+        # Test if the variables parameter is passed as a string instead of a list.
         variables = "mask"
         hf.get_gridded_files(
             options,

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -1970,11 +1970,11 @@ def test_temporal_resolution_static():
         assert data.shape == (1, 852, 586)
 
         # Test error message if the variable parameter is passed as a string instead of a list.
-        with pytest.raises(ValueError, match="must be a list, not a string"):
-            variables = "mask"
-            hf.get_gridded_files(
-                options,
-                filename_template="foo_{dataset}_{variable}.tiff",
-                variables=variables,
-            )
+        variables = "mask"
+        hf.get_gridded_files(
+            options,
+            filename_template="foo_{dataset}_{variable}.tiff",
+            variables=variables,
+        )
+        assert os.path.exists("foo_conus2_domain_mask.tiff")
     os.chdir(cd)


### PR DESCRIPTION
Add check if user passes variables as string instead of a list to use the string as a single value of a list.
This also initialized the variable file_name which caused an ugly stack trace in some error scenarios.