### PR TITLE
update variable count test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.14"
+version = "1.3.15"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -1194,7 +1194,7 @@ def test_get_variables():
     assert len(variables) == 8
     assert variables[0] == "air_temp"
     variables = hf.get_variables(grid="conus2")
-    assert len(variables) == 61
+    assert len(variables) >= 61
     assert variables[0] == "air_temp"
 
     options = {"dataset": "NLDAS2", "grid": "conus1"}


### PR DESCRIPTION
I am adding a new private dataset that includes an additional variable, `parflow_evaptrans` on the CONUS2 grid. This PR updates the test to be more flexible when considering the counts of variables we're expecting to query from the data catalog.