### PR TITLE
Register api validate pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.15"
+version = "1.3.16"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/data_catalog.py
+++ b/src/hf_hydrodata/data_catalog.py
@@ -6,12 +6,9 @@ Functions to access data_catalog metadata.
 
 import os
 from typing import List
-import requests
 import threading
-from hf_hydrodata.data_model_access import (
-    ModelTableRow,
-    load_data_model
-)
+import requests
+from hf_hydrodata.data_model_access import ModelTableRow, load_data_model
 
 HYDRODATA = "/hydrodata"
 JWT_TOKEN = None
@@ -126,9 +123,13 @@ def register_api_pin(email: str, pin: str):
 
     url = f"{HYDRODATA_URL}/api/api_pins?pin={pin}&email={email}"
     response = requests.get(url, timeout=1200)
-    if not response.status_code == 200:
+    if response.status_code == 400:
         raise ValueError(
             f"This PIN is not registered for '{email}' (expired?). Register a pin with https://hydrogen.princeton.edu/pin. Signup with https://hydrogen.princeton.edu/signup."
+        )
+    if not response.status_code == 200:
+        raise ValueError(
+            f"Unable to validate '{email}' and PIN. Check if you can register a pin with https://hydrogen.princeton.edu/pin"
         )
     pin_dir = os.path.expanduser("~/.hydrodata")
     os.makedirs(pin_dir, mode=0o700, exist_ok=True)

--- a/src/hf_hydrodata/data_catalog.py
+++ b/src/hf_hydrodata/data_catalog.py
@@ -6,6 +6,7 @@ Functions to access data_catalog metadata.
 
 import os
 from typing import List
+import requests
 import threading
 from hf_hydrodata.data_model_access import (
     ModelTableRow,
@@ -120,6 +121,15 @@ def register_api_pin(email: str, pin: str):
         hf.register_api_pin("dummy@gmail.com", "1234")
     """
 
+    if not email or not pin:
+        raise ValueError("Email and PIN are not specified in call to register_api_pin.")
+
+    url = f"{HYDRODATA_URL}/api/api_pins?pin={pin}&email={email}"
+    response = requests.get(url, timeout=1200)
+    if not response.status_code == 200:
+        raise ValueError(
+            f"This PIN is not registered for '{email}' (expired?). Register a pin with https://hydrogen.princeton.edu/pin. Signup with https://hydrogen.princeton.edu/signup."
+        )
     pin_dir = os.path.expanduser("~/.hydrodata")
     os.makedirs(pin_dir, mode=0o700, exist_ok=True)
     pin_path = f"{pin_dir}/pin.json"

--- a/tests/hf_hydrodata/test_data_catalog.py
+++ b/tests/hf_hydrodata/test_data_catalog.py
@@ -74,7 +74,7 @@ def test_get_table_row():
         entry = hf.get_table_row("variable_type", variable_type="atomspheric")
 
 
-def test_register_api():
+def test_register_api(mocker):
     """Test register and get an email pin stored in users home directory."""
 
     # Backup previous existing pin.json file so test is not destructive
@@ -85,7 +85,19 @@ def test_register_api():
     if os.path.exists(pin_file):
         os.rename(pin_file, pin_file_backup)
 
-    # Register a pin and verify it was registered
+    # Verify that register api raises an error if email is not registered
+    with pytest.raises(ValueError):
+        hf.register_api_pin("dummy@email.com", "0000")
+
+    # Then mock out requests call to verify that we can registered pin if PIN was validated
+
+    class MockResponse:
+        """Mock the flask.request response."""
+
+        def __init__(self):
+            self.status_code = 200
+
+    mocker.patch("requests.get", return_value=MockResponse())
     hf.register_api_pin("dummy@email.com", "0000")
     email, pin = hf.get_registered_api_pin()
     assert pin == "0000"

--- a/tests/hf_hydrodata/test_data_catalog.py
+++ b/tests/hf_hydrodata/test_data_catalog.py
@@ -89,8 +89,7 @@ def test_register_api(mocker):
     with pytest.raises(ValueError):
         hf.register_api_pin("dummy@email.com", "0000")
 
-    # Then mock out requests call to verify that we can registered pin if PIN was validated
-
+    # Then mock out requests.get call that validates the pin so we can test writing to the register pin file.
     class MockResponse:
         """Mock the flask.request response."""
 


### PR DESCRIPTION
Add an API call to the register_api_pin() function in hf_hydrodata to validate that the email/pin is correctly registered and valid.
This prevents users from making the mistake of registering a different email address than they registered with the UI and then getting misleading error messages later when remote calls do not work (this happened to Laura).