### PR TITLE
fix tests because of huc_boundary file changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.19"
+version = "1.3.20"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -841,13 +841,13 @@ def test_get_huc_bbox_conus2():
 
     gr.HYDRODATA = "/hydrodata"
     bbox = hf.get_huc_bbox("conus2", ["101900"])
-    assert bbox == [1439, 1573, 1844, 1851]
+    assert bbox == [1439, 1573, 1909, 1851]
     bbox = hf.get_huc_bbox("conus2", ["1019"])
-    assert bbox == [1439, 1573, 1844, 1851]
+    assert bbox == [1439, 1573, 1909, 1851]
     bbox = hf.get_huc_bbox("conus2", ["10"])
-    assert bbox == [948, 1353, 2741, 2783]
+    assert bbox == [948, 1353, 2786, 2783]
     bbox = hf.get_huc_bbox("conus2", ["15020018"])
-    assert bbox == [940, 1333, 1060, 1422]
+    assert bbox == [927, 1331, 1061, 1422]
 
     # Check the bbox is correct for HUC 15 (this failed with old get_huc_box code)
     bbox = hf.get_huc_bbox("conus2", ["15"])
@@ -855,13 +855,11 @@ def test_get_huc_bbox_conus2():
 
     # Check the bbox for HUC16 that is ajacent to the old failing HUC 15
     bbox = hf.get_huc_bbox("conus2", ["16"])
-    assert bbox == [279, 1337, 1130, 2152]
+    assert bbox == [279, 1337, 1130, 2137]
 
     # Check the bbox passes for either the value from the old float32 tiffs or the new int32 tiffs
-    bbox = hf.get_huc_bbox("conus2", ["1019000404"])
-    assert (bbox == [1468, 1664, 1550, 1693]) or (bbox == [1504, 1670, 1550, 1687])
     bbox = hf.get_huc_bbox("conus2", ["10190004"])
-    assert (bbox == [1468, 1664, 1550, 1693]) or (bbox == [1504, 1670, 1550, 1687])
+    assert (bbox == [1468, 1665, 1550, 1694]) or (bbox == [1504, 1670, 1550, 1687])
 
 
 def test_latlng_to_grid_out_of_bounds():

--- a/tests/hf_hydrodata/test_point.py
+++ b/tests/hf_hydrodata/test_point.py
@@ -1755,7 +1755,7 @@ def test_get_metadata_by_huc():
         huc_id=["02040106"],
         grid="conus2",
     )
-    assert len(df) == 14
+    assert len(df) == 16
     # site ID that is in bbox but not in huc
     assert "01470736" not in list(df["site_id"])
 
@@ -1772,7 +1772,7 @@ def test_get_data_by_huc():
         huc_id=["02040106"],
         grid="conus2",
     )
-    assert df.shape[1] == 15
+    assert df.shape[1] == 17
     # site ID that is in bbox but not in huc
     assert "01470736" not in list(df.columns)
 


### PR DESCRIPTION
Fix some unit tests that started failing because we released new huc boundary files.
