### PR TITLE
Add flexibility to ambiguous filter test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.20"
+version = "1.3.21"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -1097,7 +1097,12 @@ def test_ambiguous_filter():
 
     with pytest.raises(ValueError) as info:
         hf.get_catalog_entry(options)
-    assert "variable = '" in str(info.value) and "'downward_longwave" in str(info.value)
+    assert "variable = '" in str(info.value)
+
+    # check suggestion of variable filter
+    var_options = ["'air_temp", "'east_windspeed", "'north_windspeed", "'atmospheric_pressure",
+                   "'precipitation", "'downward_longwave", "'downward_shortwave", "'specific_humidity"]
+    assert any(v in str(info.value) for v in var_options)
 
 
 def test_get_huc_from_point():


### PR DESCRIPTION
The test `test_gridded:test_ambiguous_filter` is sometimes failing because it is looking for a specific variable suggestion (downward_longwave). Sometimes a set of other (still-appropriate) variables are suggested that does not include downward_longwave, which causes this test to fail.

This PR adds flexibility to this test to check against the full list of appropriate suggestions.

This is an example of the failing test.
<img width="1142" alt="Screenshot 2025-02-14 at 11 47 17 AM" src="https://github.com/user-attachments/assets/8fe30fed-4a41-41fb-b2c1-d9137af7ea06" />
