### PR TITLE
add substitution key for parflow runname

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.21"
+version = "1.3.22"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -2356,6 +2356,8 @@ def _substitute_datapath(
     dataset_var = entry.get("dataset_var") if entry.get("dataset_var") else variable
     dataset = entry.get("dataset")
     aggregation = entry.get("aggregation")
+    temporal_resolution = entry.get("temporal_resolution")
+    dataset_version = entry.get("dataset_version")
     file_daynum = (time_value - start_time).days if start_time else 0
     wy = ""
     cy = ""
@@ -2380,6 +2382,7 @@ def _substitute_datapath(
     run_number = options.get("run_number")
     site_id = options.get("site_id")
     level = options.get("level")
+    parflow_runname = ""
     if "{level}" in path and not level:
         raise ValueError("No 'level' specified in filter options.")
     if "{site_id}" in path and not site_id:
@@ -2398,6 +2401,15 @@ def _substitute_datapath(
         wy_start_24hr = (time_value - wy_start).days * 24 + 1
         wy_end_24hr = (time_value - wy_start).days * 24 + 24
         mmddyyyy = datetime.datetime.strftime(time_value, "%m%d%Y")
+
+    # Raw CONUS2.1 simulations data is named with "spinup" in the runname for WY2003.
+    # For other water years, the phrase "conus21" is used in the runname instead of "spinup".
+    if (dataset=="conus2_baseline") and (temporal_resolution=="hourly") and (dataset_version=="2.1"):
+        if wy == "2003":
+            parflow_runname = "spinup"
+        else:
+            parflow_runname = "conus21"
+
     datapath = path.format(
         dataset_var=dataset_var,
         wy=wy,
@@ -2426,7 +2438,9 @@ def _substitute_datapath(
         dataset=dataset,
         variable=variable,
         aggregation=aggregation,
+        parflow_runname=parflow_runname
     )
+
     return datapath
 
 


### PR DESCRIPTION
Add special case handling for ParFlow CONUS2.1 simulation results. The raw files contain different ParFlow run name prefixes that otherwise are not able to be standardized within the current set of substitution keys.