### PR TITLE
update CONUS2 i/j grid values; add nwm site network

### DIFF
--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -6,8 +6,16 @@ on:
   schedule:
     - cron: '0 8 * * 1'
 
-  # run with each new Pull Request opened to the main branch
-  pull_request:
+  # Run GitHub Actions when the main branch is modified.
+  # This includes after code changes are merged to main from a PR.
+  # Merging to main requires the Verde-based Jenkins jobs to pass.
+
+  # If this remote GitHub Action fails, it means there is a discrepancy with the 
+  # version of hf_hydrodata installed into the hydrogen-service API.
+  # If this fails:
+  #  - Trigger a manual re-build of the hydrogen-service Jenkins job to rebuild the API
+  #  - Manually re-run the failing hf_hydrodata GitHub Actions job
+  push:
     branches:
       - main
 

--- a/docs/source/available_metadata.rst
+++ b/docs/source/available_metadata.rst
@@ -90,13 +90,17 @@ There are several variables that are returned by all ``get_point_metadata()`` fu
     * - doi
       - If applicable, the DOI associated with the site, as provided by the contributing agency.
     * - conus1_i
-      - Integer number of grid cells in the horizonal direction away from the CONUS1 grid origin of (0,0).
+      - Integer number of grid cells in the horizontal direction away from the CONUS1 grid origin of (0,0).
     * - conus1_j
       - Integer number of grid cells in the vertical direction away from the CONUS1 grid origin of (0,0).
     * - conus2_i
-      - Integer number of grid cells in the horizonal direction away from the CONUS2 grid origin of (0,0).
+      - Integer number of grid cells in the horizontal direction away from the CONUS2 grid origin of (0,0).
     * - conus2_j
       - Integer number of grid cells in the vertical direction away from the CONUS2 grid origin of (0,0).
+    * - conus2_i_nwm
+      - Integer number of grid cells in the horizontal direction away from the CONUS2 grid origin of (0,0). Mapping available for only stream gages in the NWM and described in `Zhang et al. 2021 <https://essd.copernicus.org/articles/13/3263/2021/>`_.
+    * - conus2_j_nwm
+      - Integer number of grid cells in the vertical direction away from the CONUS2 grid origin of (0,0). Mapping available for only stream gages in the NWM and described in `Zhang et al. 2021 <https://essd.copernicus.org/articles/13/3263/2021/>`_.
 
 
 Stream Gage Metadata

--- a/docs/source/point_data/examples/example_site_networks.ipynb
+++ b/docs/source/point_data/examples/example_site_networks.ipynb
@@ -28,6 +28,7 @@
     "  - [GAGESII reference gages](https://pubs.usgs.gov/publication/70046617) ('gagesii_reference')\n",
     "  - [HCDN-2009](https://water.usgs.gov/osw/hcdn-2009/) ('hcdn2009')\n",
     "  - [CAMELS](https://ral.ucar.edu/solutions/products/camels) ('camels')\n",
+    "  - [NWM](https://essd.copernicus.org/articles/13/3263/2021/) ('nwm')\n",
     "\n",
     "For USGS groundwater wells, the currently-supported set of site networks include:\n",
     "\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.21"
+version = "1.3.22"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/tests/hf_hydrodata/test_point.py
+++ b/tests/hf_hydrodata/test_point.py
@@ -1386,8 +1386,8 @@ def test_grid_bounds_conus2_list():
         grid="conus2",
         grid_bounds=[1500, 1300, 1700, 1500],
     )
-    assert df.shape[1] >= 19
-    assert df.shape[1] <= 25
+    assert df.shape[1] >= 15
+    assert df.shape[1] <= 100
     assert "07119500" in df.columns
     assert "07208500" in df.columns
 
@@ -1401,8 +1401,8 @@ def test_grid_bounds_conus2_list():
         grid="conus2",
         grid_bounds=[1500, 1300, 1700, 1500],
     )
-    assert metadata_df.shape[0] >= 18
-    assert metadata_df.shape[0] <= 24
+    assert metadata_df.shape[0] >= 15
+    assert metadata_df.shape[0] <= 100
     assert "07119500" in list(metadata_df["site_id"])
     assert "07208500" in list(metadata_df["site_id"])
 
@@ -1421,8 +1421,8 @@ def test_grid_bounds_conus2_dict():
             "grid_bounds": [1500, 1300, 1700, 1500],
         }
     )
-    assert df.shape[1] >= 19
-    assert df.shape[1] <= 25
+    assert df.shape[1] >= 15
+    assert df.shape[1] <= 100
     assert "07119500" in df.columns
     assert "07208500" in df.columns
 
@@ -1438,8 +1438,8 @@ def test_grid_bounds_conus2_dict():
             "grid_bounds": [1500, 1300, 1700, 1500],
         }
     )
-    assert metadata_df.shape[0] >= 18
-    assert metadata_df.shape[0] <= 24
+    assert metadata_df.shape[0] >= 15
+    assert metadata_df.shape[0] <= 100
     assert "07119500" in list(metadata_df["site_id"])
     assert "07208500" in list(metadata_df["site_id"])
 
@@ -1574,8 +1574,8 @@ def test_get_variables_grid_bounds_conus2_list():
         grid="conus2",
         grid_bounds=[1500, 1300, 1700, 1500],
     )
-    assert df.shape[0] >= 18
-    assert df.shape[0] <= 24
+    assert df.shape[0] >= 15
+    assert df.shape[0] <= 100
     assert "07119500" in list(df["site_id"])
     assert "07208500" in list(df["site_id"])
 
@@ -1594,8 +1594,8 @@ def test_get_variables_grid_bounds_conus2_dict():
             "grid_bounds": [1500, 1300, 1700, 1500],
         }
     )
-    assert df.shape[0] >= 18
-    assert df.shape[0] <= 24
+    assert df.shape[0] >= 15
+    assert df.shape[0] <= 100
     assert "07119500" in list(df["site_id"])
     assert "07208500" in list(df["site_id"])
 

--- a/tests/hf_hydrodata/test_point.py
+++ b/tests/hf_hydrodata/test_point.py
@@ -637,7 +637,7 @@ def test_get_metadata_streamflow():
         longitude_range=(-75, -50),
     )
     assert len(metadata_df) == 4
-    assert len(metadata_df.columns) == 23
+    assert len(metadata_df.columns) == 25
     assert "01011000" in list(metadata_df["site_id"])
 
 
@@ -656,7 +656,7 @@ def test_get_metadata_streamflow_dict():
         }
     )
     assert len(metadata_df) == 4
-    assert len(metadata_df.columns) == 23
+    assert len(metadata_df.columns) == 25
     assert "01011000" in list(metadata_df["site_id"])
 
 
@@ -673,7 +673,7 @@ def test_get_metadata_streamflow_hourly():
         longitude_range=(-75, -50),
     )
     assert len(metadata_df) == 4
-    assert len(metadata_df.columns) == 23
+    assert len(metadata_df.columns) == 25
     assert "01011000" in list(metadata_df["site_id"])
 
 
@@ -1848,7 +1848,7 @@ def test_huc_list():
         huc_id=["02040106", "02040106"],
         grid="conus2",
     )
-    assert df.shape[1] == 23
+    assert df.shape[1] == 25
 
 
 def test_depth_level_provided_not_sm():

--- a/tests/hf_hydrodata/test_point.py
+++ b/tests/hf_hydrodata/test_point.py
@@ -820,6 +820,36 @@ def test_site_networks_filter_list():
     assert len(metadata_df) == 60
 
 
+def test_site_networks_filter_nwm():
+    """Test for using site_networks filter with nwm list"""
+    nwm_sites_metadata = point.get_point_metadata(
+        dataset="usgs_nwis",
+        variable="streamflow",
+        temporal_resolution="daily",
+        aggregation="mean",
+        date_start="2002-01-01",
+        date_end="2002-01-05",
+        state="NJ",
+        latitude_range=(40, 41),
+        longitude_range=(-75, -74),
+        site_networks=["nwm"],
+    )
+    assert len(nwm_sites_metadata) == 60
+
+    all_sites_metadata = point.get_point_metadata(
+        dataset="usgs_nwis",
+        variable="streamflow",
+        temporal_resolution="daily",
+        aggregation="mean",
+        date_start="2002-01-01",
+        date_end="2002-01-05",
+        state="NJ",
+        latitude_range=(40, 41),
+        longitude_range=(-75, -74),
+    )
+    assert len(all_sites_metadata) == 65
+
+
 def test_site_networks_filter_list_wtd():
     """Test for using site_networks filter as a list with water table depth variable"""
     data_df = point.get_point_data(
@@ -1585,7 +1615,10 @@ def test_fail_no_grid_get_site_variables():
             date_end="2002-01-05",
             grid_bounds=[1500, 1300, 1700, 1500],
         )
-    assert "When providing the parameter `grid_bounds`, please also provide the parameter `grid`" in str(exc.value)
+    assert (
+        "When providing the parameter `grid_bounds`, please also provide the parameter `grid`"
+        in str(exc.value)
+    )
 
 
 def test_fail_no_sites_get_site_variables():


### PR DESCRIPTION
This PR corresponds to efforts to expand and update the CONUS2 i/j mapping values for stream gages (`conus2_i`, `conus2_j`). For reproducibility purposes, we are preserving the previous i/j values in the new metadata fields `conus2_i_nwm` and `conus2_j_nwm`. This PR adds documentation for those metadata fields and adds them to the set of variables included in stream gage metadata returned to the user. Several test bounds are expanded to account for many more gages having `conus2_i` and `conus2_j` values.

Additionally, this PR adds support for a new network list: `nwm`. This network list corresponds to the subset of stream gages that previously had CONUS2 i/j mappings. The purpose for adding this set of gages as a network list is to help users easily filter on only those gages that previously had the CONUS2 i/j mapping values present.