### PR TITLE
Fix point tests

### DIFF
--- a/docs/source/available_metadata.rst
+++ b/docs/source/available_metadata.rst
@@ -97,11 +97,6 @@ There are several variables that are returned by all ``get_point_metadata()`` fu
       - Integer number of grid cells in the horizontal direction away from the CONUS2 grid origin of (0,0).
     * - conus2_j
       - Integer number of grid cells in the vertical direction away from the CONUS2 grid origin of (0,0).
-    * - conus2_i_nwm
-      - Integer number of grid cells in the horizontal direction away from the CONUS2 grid origin of (0,0). Mapping available for only stream gages in the NWM and described in `Zhang et al. 2021 <https://essd.copernicus.org/articles/13/3263/2021/>`_.
-    * - conus2_j_nwm
-      - Integer number of grid cells in the vertical direction away from the CONUS2 grid origin of (0,0). Mapping available for only stream gages in the NWM and described in `Zhang et al. 2021 <https://essd.copernicus.org/articles/13/3263/2021/>`_.
-
 
 Stream Gage Metadata
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -122,6 +117,11 @@ be produced when ``dataset='usgs_nwis'`` and ``variable='streamflow'``:
       - Site elevation (meters), as per the `GAGES-II metadata <https://www.sciencebase.gov/catalog/item/631405bbd34e36012efa304a>`_.
     * - usgs_drainage_area
       - Drainage area (square miles) for the site, as per the USGS.
+    * - conus2_i_nwm
+      - Integer number of grid cells in the horizontal direction away from the CONUS2 grid origin of (0,0). Mapping available for only stream gages in the NWM and described in `Zhang et al. 2021 <https://essd.copernicus.org/articles/13/3263/2021/>`_.
+    * - conus2_j_nwm
+      - Integer number of grid cells in the vertical direction away from the CONUS2 grid origin of (0,0). Mapping available for only stream gages in the NWM and described in `Zhang et al. 2021 <https://essd.copernicus.org/articles/13/3263/2021/>`_.
+
 
 Groundwater Well Metadata
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.22"
+version = "1.3.23"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/tests/hf_hydrodata/test_point.py
+++ b/tests/hf_hydrodata/test_point.py
@@ -1788,7 +1788,7 @@ def test_get_metadata_by_huc():
         huc_id=["02040106"],
         grid="conus2",
     )
-    assert len(df) == 16
+    assert len(df) == 15
     # site ID that is in bbox but not in huc
     assert "01470736" not in list(df["site_id"])
 
@@ -1805,7 +1805,7 @@ def test_get_data_by_huc():
         huc_id=["02040106"],
         grid="conus2",
     )
-    assert df.shape[1] == 17
+    assert df.shape[1] == 16
     # site ID that is in bbox but not in huc
     assert "01470736" not in list(df.columns)
 


### PR DESCRIPTION
This PR fixes two tests within the point module. These tests now accommodate the changed number of sites within a HUC, following the previous change that increased the number of gages with grid mappings.

Also included is a small docs update, to place the new CONUS2 i/j grid variables within the stream gage attributes section. These variables are only returned for stream gages, not all point site types.