### PR TITLE
fix generation of doi citations

### DIFF
--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -182,7 +182,7 @@ def _generate_dois_citation(dois_entry, stream):
 
     if dois_entry:
         if "http://" in dois_entry or "https://" in dois_entry:
-            stream.write(f"{dois_entry}\n\n")
+            stream.write(f"* {dois_entry}\n\n")
         else:
             stream.write(f"* https://doi.org/{dois_entry}\n\n")
 

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -155,11 +155,9 @@ def _generate_dataset_docs(dataset_id, dataset_text_map, directory):
                 "Please refer to the following citations for more information on this dataset and cite them if you use the data\n\n"
             )
             for entry in paper_dois.split(" "):
-                if entry:
-                    stream.write(f"* https://doi.org/{entry}\n\n")
+                _generate_dois_citation(entry, stream)
             for entry in dataset_dois.split(" "):
-                if entry:
-                    stream.write(f"* {entry}\n\n")
+                _generate_dois_citation(entry, stream)
 
         if dataset_start_date or len(grids) > 0:
             stream.write("**Extent and Resolution**:\n\n")
@@ -172,6 +170,21 @@ def _generate_dataset_docs(dataset_id, dataset_text_map, directory):
             _generate_grid_extent_docs(grids, stream)
 
         _generate_dataset_variable_docs(dataset_row, stream)
+
+
+def _generate_dois_citation(dois_entry, stream):
+    """
+    Generate the read-the-docs for either a paper_dois entry or a dataset_dois entry.
+
+    If the entry does not contain its own http header then add https://doi.org
+    otherwise the entry is the http reference link.
+    """
+
+    if dois_entry:
+        if "http://" in dois_entry or "https://" in dois_entry:
+            stream.write(f"{dois_entry}\n\n")
+        else:
+            stream.write(f"* https://doi.org/{dois_entry}\n\n")
 
 
 def _generate_grid_extent_docs(grids, stream):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.23"
+version = "1.3.24"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"


### PR DESCRIPTION
Fix the generation of the read-the-docs for docs citations links.

Change the read-the-docs generation so if the data catalog entry already contains https:// then use the entry as the link, otherwise add the https://doi.org prefix to construct a valid citation URL link to the reference.

Previously only paper_dois entry got the https://doi.org prefix, but dataset_dois did not. However, the data catalog had entries with and without in both categories. This change makes the entries in the data catalog more robust.
