### PR TITLE
fix gridded_files projection and add conus2_domain mask variables tes…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.24"
+version = "1.3.25"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -852,7 +852,8 @@ def _create_gridded_files_geotiff(
     else:
         # If there no grid_bounds then the origin is the same as origin of the grid itself
         left_origin = x_origin
-        top_origin = y_origin
+        top_origin = y_origin + grid_data["shape"][1] * 1000
+
     # Remove false northing and false easting from CRS since this is handled by transform origins
     pos = crs_string.find("+x_0=")
     crs_string = crs_string[0:pos] if pos > 0 else crs_string


### PR DESCRIPTION
Fix the issue with get_gridded_files creating the wrong origin values in the projection for tiff files created with a full conus2 grid. It worked before for tiff files with grid_bounds, but had the wrong y origin value for full conus2 files.

Also added unit tests for the new variables in the data catalog for conus2_bounds for variables mask_top, mask_bottom, mask_left, mask_right, mask_front, mask_back.
