### PR TITLE
fix failing unit test missing parameters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.25"
+version = "1.3.26"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -2005,10 +2005,10 @@ def test_temporal_resolution_static(tmp_path):
     os.chdir(cd)
 
 
-def test_gridded_files_crs_full_conus2(tmp_path):
+def test_gridded_files_crs_full_conus1(tmp_path):
     """
-    Test get_gridded_files crs and origin creating full conus2 sized tiff file.
-    The origin of the projection in the generated tiff file must reflect the full conus2 position.
+    Test get_gridded_files crs and origin creating full conus1 sized tiff file.
+    The origin of the projection in the generated tiff file must reflect the full conus1 position.
     """
 
     cd = os.getcwd()
@@ -2019,6 +2019,8 @@ def test_gridded_files_crs_full_conus2(tmp_path):
     options = {
         "dataset": dataset,
         "variable": variable,
+        "start_time": "2023-10-01",
+        "end_time": "2023-10-02",
     }
     hf.get_gridded_files(
         options,
@@ -2038,7 +2040,7 @@ def test_gridded_files_crs_full_conus2(tmp_path):
 
 def test_gridded_files_crs_subgrid(tmp_path):
     """
-    Test get_gridded_files crs and origin creating full conus2 sized tiff file.
+    Test get_gridded_files crs and origin creating a subset conus1 tiff file.
     The origin in the tiff file projection must reflect the grid_bounds.
     """
 
@@ -2050,6 +2052,8 @@ def test_gridded_files_crs_subgrid(tmp_path):
     options = {
         "dataset": dataset,
         "variable": variable,
+        "start_time": "2023-10-01",
+        "end_time": "2023-10-02",
         "grid_bounds": [1000, 1000, 1010, 1010],
     }
     hf.get_gridded_files(


### PR DESCRIPTION
The daily-run unit tests are currently failing due to missing `start_time` and `end_time` parameters in the new `test_gridded/test_gridded_files_crs` unit tests. This PR adds in a date within the range for which the requested dataset is valid.