### PR TITLE
add typing extensions that is now required by rasterio and xarray

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.26"
+version = "1.3.27"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"
@@ -24,6 +24,7 @@ scipy = ">=1.10.0"
 dask = ">=2020.12.0"
 pyshp = ">=2.3.1"
 shapely = ">=2.0.2"
+typing_extensions = ">=4.14.0"
 # rasterio = ">=1.3.9"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dask = ">=2020.12.0"
 pyshp = ">=2.3.1"
 shapely = ">=2.0.2"
 typing_extensions = ">=4.14.0"
-# rasterio = ">=1.3.9"
+# Optional for now rasterio = ">=1.3.9"
 
 [tool.poetry.dev-dependencies]
 sphinx = ">=6.1.3"


### PR DESCRIPTION
Add a dependency module "typing_extensions" that is now required by the most recent xarray and rioxarray.
The lack of this dependency broke a Jenkins job after installing the most recent hf_hydrodata.
