### PR TITLE
update stream gage count in HUC filter tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.27"
+version = "1.3.28"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/tests/hf_hydrodata/test_point.py
+++ b/tests/hf_hydrodata/test_point.py
@@ -1788,7 +1788,7 @@ def test_get_metadata_by_huc():
         huc_id=["02040106"],
         grid="conus2",
     )
-    assert len(df) == 15
+    assert len(df) == 16
     # site ID that is in bbox but not in huc
     assert "01470736" not in list(df["site_id"])
 
@@ -1805,7 +1805,7 @@ def test_get_data_by_huc():
         huc_id=["02040106"],
         grid="conus2",
     )
-    assert df.shape[1] == 16
+    assert df.shape[1] == 17
     # site ID that is in bbox but not in huc
     assert "01470736" not in list(df.columns)
 


### PR DESCRIPTION
We released updated `conus2_i` and `conus2_j` metadata values today (for stream gages only) after reviewing existing values against known stream locations.

These mappings impact the number of sites that get filtered via HUCs. HUC filtering uses the `conus2_i` and `conus2_j` grid locations for point filtering. This PR updates the tests of stream gage site counts within a single HUC to account for the different mappings. This change is expected.