### PR TITLE
fix bug with latlon_bounds option in get_gridded_data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.28"
+version = "1.3.29"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -1525,8 +1525,8 @@ def _convert_json_to_strings(options):
     options : dictionary
         request options.
     """
-    options = dict(options)
-    for key, value in options.items():
+    options_copy = dict(options)
+    for key, value in options_copy.items():
         if key == "grid_bounds":
             if not isinstance(value, str):
                 options[key] = json.dumps(value)

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -2091,3 +2091,13 @@ def test_mask_variables():
         }
         data = hf.get_gridded_data(options)
         assert data.shape == (10, 10)
+
+def test_latlon_bounds():
+    """
+    Test get_gridded_data with latlon_bounds. 
+    This used to failed when run remote with dictionary changed size.
+    """
+
+    latlon_bounds = [40.7334013940,-105.7923988288, 41.1959974578,-105.2224758822]
+    latitude = hf.get_gridded_data({"variable": "latitude", "grid": "conus2", "latlon_bounds": latlon_bounds})
+    assert latitude.shape == (45, 51)


### PR DESCRIPTION
Fix a bug and added a unit tests for passing latlon_bounds to get_gridded_data.
This worked before when run locally, but failed when run remotely when trying to serialize the filter options parameters to a string. It failed with an error because it tried to change the dict while iterating through the same dict and this raised an error. Now it makes a copy of the dict first and iterates through the copy to get the keys during this serialization, this fixed the bug.