### PR TITLE
fix options dict passed via api

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.29"
+version = "1.3.30"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -1525,8 +1525,10 @@ def _convert_json_to_strings(options):
     options : dictionary
         request options.
     """
-    options_copy = dict(options)
-    for key, value in options_copy.items():
+    options = dict(options)
+    keys = [str(k) for k in options.keys()]
+    for key in keys:
+        value = options[key]
         if key == "grid_bounds":
             if not isinstance(value, str):
                 options[key] = json.dumps(value)

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -2033,8 +2033,8 @@ def test_gridded_files_crs_full_conus1(tmp_path):
         assert crs.startswith("+proj=lcc +lat_0=39")
         assert "+lat_2=45" in crs
         transform = fp.rio.transform()
-        assert transform.c == -1885055.4995
-        assert transform.f == 1283042.9346
+        assert pytest.approx(transform.c) == -1885055.4995
+        assert pytest.approx(transform.f) == 1283042.9346
     os.chdir(cd)
 
 
@@ -2067,8 +2067,8 @@ def test_gridded_files_crs_subgrid(tmp_path):
         assert crs.startswith("+proj=lcc +lat_0=39")
         assert "+lat_2=45" in crs
         transform = fp.rio.transform()
-        assert transform.c == -885055.4994999999
-        assert transform.f == 405042.93460000004
+        assert pytest.approx(transform.c) == -885055.49950
+        assert pytest.approx(transform.f) == 405042.93460
     os.chdir(cd)
 
 
@@ -2092,12 +2092,15 @@ def test_mask_variables():
         data = hf.get_gridded_data(options)
         assert data.shape == (10, 10)
 
+
 def test_latlon_bounds():
     """
-    Test get_gridded_data with latlon_bounds. 
+    Test get_gridded_data with latlon_bounds.
     This used to failed when run remote with dictionary changed size.
     """
 
-    latlon_bounds = [40.7334013940,-105.7923988288, 41.1959974578,-105.2224758822]
-    latitude = hf.get_gridded_data({"variable": "latitude", "grid": "conus2", "latlon_bounds": latlon_bounds})
+    latlon_bounds = [40.7334013940, -105.7923988288, 41.1959974578, -105.2224758822]
+    latitude = hf.get_gridded_data(
+        {"variable": "latitude", "grid": "conus2", "latlon_bounds": latlon_bounds}
+    )
     assert latitude.shape == (45, 51)


### PR DESCRIPTION
This code fixes a bug encountered when running certain code (test case: `gridded.py/test_gridded_files_crs_subgrid`) from a local user machine (via the API). The options dictionary was being left as a string and this caused later logic to not be implemented as expected.

This resulted in a failing test when running via GitHub Actions. 

This PR also adjusts some of the tests to use `pytest.approx` for comparison purposes.