### PR TITLE
update cw3e end dates in data catalog

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.30"
+version = "1.3.31"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"


### PR DESCRIPTION
This PR adds a function that updates the end dates for the CW3E version 1.0 dataset in the data catalog. We now intake and pre-process this dataset weekly. This new function adds logic for determining the appropriate end dates for this CW3E version 1.0 dataset so that `hf_hydrodata` users can access the most recent data available.