### PR TITLE
Huc version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.32"
+version = "1.3.33"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -1396,7 +1396,10 @@ def get_huc_bbox(grid: str, huc_id_list: List[str]) -> List[int]:
 
     Raises:
         ValueError:     if all the HUC id are not at the same level (same length).
-        ValueError:     if grid is not valid.
+        ValueError:     if grid is not valid or a HUC_VERSION environment variable is not valid.
+
+    If the environment variable HUC_VERSION is set this will cause the function to use the HUC boundaries for
+    that dataset_version. The versions 2025_06, 2025_01, 2024_11 are supported as well as blank to get latest.
 
     Example:
 

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -590,16 +590,16 @@ def get_gridded_files(
                 if file_name.endswith(".nc") and not file_name == last_file_name:
                     if last_file_name:
                         _execute_dask_items(dask_items, state, last_file_name)
-                    state = _FileDownloadState(
-                        options_copy,
-                        filename_template,
-                        temporal_resolution,
-                        start_time,
-                        end_time,
-                        verbose,
-                    )
-                    state.generate_time_coords(file_time)
-                    dask_items = []
+                        state = _FileDownloadState(
+                            options_copy,
+                            filename_template,
+                            temporal_resolution,
+                            start_time,
+                            end_time,
+                            verbose,
+                        )
+                        state.generate_time_coords(file_time)
+                        dask_items = []
                 dask_items.append(
                     dask.delayed(_load_gridded_file_entry)(
                         state, entry, options_copy, file_time
@@ -1296,6 +1296,7 @@ def _apply_mask(data, entry, options):
                 "grid": grid,
                 "grid_bounds": bbox,
                 "level": level,
+                "dataset_version": os.getenv("HUC_VERSION", "")
             }
         )
         # Apply the HUC mask to the data, mask with all huc_ids
@@ -1310,6 +1311,7 @@ def _apply_mask(data, entry, options):
                 "grid": grid,
                 "grid_bounds": grid_bounds,
                 "level": 2,
+                "dataset_version": os.getenv("HUC_VERSION", "")
             }
         )
         data = np.where(mask > 0, data, np.nan)
@@ -2082,6 +2084,7 @@ def __get_geotiff(grid: str, level: int) -> xr.Dataset:
         "variable": "huc_map",
         "grid": grid,
         "level": str(level),
+        "dataset_version": os.getenv("HUC_VERSION", "")
     }
     entry = dc.get_catalog_entry(options)
     if entry is None:
@@ -2698,7 +2701,6 @@ def _get_grid_bounds(grid: str, options: dict) -> List[float]:
         huc_id_list = huc_id.split(",")
         grid_bounds = get_huc_bbox(grid, huc_id_list)
     return grid_bounds
-
 
 class _FileDownloadState:
     """State information about the state of the get_gridded_files() method during thread execution."""

--- a/src/hf_hydrodata/point.py
+++ b/src/hf_hydrodata/point.py
@@ -2224,6 +2224,7 @@ def _get_huc_query(options, param_list, conn, dataset=None, variable=None):
             "grid": grid,
             "file_type": "tiff",
             "level": level,
+            "dataset_version": os.getenv("HUC_VERSION", "")
         }
     )
     conus_huc_mask = np.isin(conus_hucs, hucs).squeeze()

--- a/src/hf_hydrodata/point.py
+++ b/src/hf_hydrodata/point.py
@@ -130,6 +130,10 @@ def get_point_data(*args, **kwargs):
         DataFrame with columns for each site_id satisfying input filters. Rows represent
         the date range requested from date_start and/or date_end, or the broadest range of
         data available for returned sites if no date range is explicitly requested.
+
+    If the environment variable HUC_VERSION is set this will cause the function to use the HUC boundaries for
+    that dataset_version when HUC is passed as a option.
+    The versions 2025_06, 2025_01, 2024_11 are supported as well as blank to use the latest HUC boundaries.       
     """
     if len(args) > 0 and isinstance(args[0], dict):
         options = args[0]

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -2134,7 +2134,7 @@ def test_get_gridded_files_to_netcdf_min():
         da_min = ds["Temp_min"].values
         # The NetCDF file has time dimension of 365 regardless of the time filter
         assert da_min.shape == (365, 19, 48)
-        # The day 8/4/1990 is day index 306 in the water year of the requested data
+        # The day 8/4/1990 is day index 307 in the water year of the requested data
         assert round(da_min[307, 0, 0], 2) == 282.75
 
 


### PR DESCRIPTION
Support the environment variable HUC_VERSION to cause the get_huc_bbox() function to return the HUC boundaries using the dataset_version specified by the environment variables. The values 2025_06, 2025_01, 2024_11 are supported as well as blank or null to use the latest version of the HUC boundary files. The new dataset_version entries were added to the SQL data catalog to support this.

This should work both locally and remotely since the environment variable is used to add the dataset_version parameters to calls to get_gridded_data() locally which is then passed in the API call.

This PR also fixes an obscure issue in get_gridded_files when requested to create a .nc file that contained multiple aggregation values.  This occurred when the aggregation was not specified in the input filter and the variable (e.g. air_temp) contained  multiple aggregations of that variable. Previously, the different aggregations did not always return the correct data. This was fixed by changing the indent of a loop in the get_gridded_files() function so the state and the dask_items variable were reset when iterating through different aggregations. It worked fine previously if the aggregation was specified or if the variable did not contain different aggregations.
