### PR TITLE
Default huc version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.34"
+version = "1.3.35"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.33"
+version = "1.3.34"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/data_catalog.py
+++ b/src/hf_hydrodata/data_catalog.py
@@ -432,7 +432,7 @@ def _get_preferred_catalog_entry(entries: List[dict]) -> dict:
                 "preference_state_key": "aggregation",
                 "preferred_values": ["mean", "sum", "median", "static", "max", "min"],
             },
-            {"preference_state_key": "dataset_version", "preferred_values": None},
+            {"preference_state_key": "dataset_version", "preferred_values": [None, "", "1.0"]},
         ]
 
         # evaluate the ambiguous data catalog entries against a preference state to find preferences

--- a/src/hf_hydrodata/data_catalog.py
+++ b/src/hf_hydrodata/data_catalog.py
@@ -432,7 +432,7 @@ def _get_preferred_catalog_entry(entries: List[dict]) -> dict:
                 "preference_state_key": "aggregation",
                 "preferred_values": ["mean", "sum", "median", "static", "max", "min"],
             },
-            {"preference_state_key": "dataset_version", "preferred_values": [None, "", "1.0"]},
+            {"preference_state_key": "dataset_version", "preferred_values": None},
         ]
 
         # evaluate the ambiguous data catalog entries against a preference state to find preferences

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -1296,7 +1296,7 @@ def _apply_mask(data, entry, options):
                 "grid": grid,
                 "grid_bounds": bbox,
                 "level": level,
-                "dataset_version": os.getenv("HUC_VERSION", ""),
+                "dataset_version": os.getenv("HUC_VERSION", None),
             }
         )
         # Apply the HUC mask to the data, mask with all huc_ids
@@ -1311,7 +1311,7 @@ def _apply_mask(data, entry, options):
                 "grid": grid,
                 "grid_bounds": grid_bounds,
                 "level": 2,
-                "dataset_version": os.getenv("HUC_VERSION", ""),
+                "dataset_version": os.getenv("HUC_VERSION", None),
             }
         )
         data = np.where(mask > 0, data, np.nan)
@@ -2087,7 +2087,7 @@ def __get_geotiff(grid: str, level: int) -> xr.Dataset:
         "variable": "huc_map",
         "grid": grid,
         "level": str(level),
-        "dataset_version": os.getenv("HUC_VERSION", ""),
+        "dataset_version": os.getenv("HUC_VERSION", None),
     }
     entry = dc.get_catalog_entry(options)
     if entry is None:

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -570,7 +570,6 @@ def get_gridded_files(
         options["end_time"] = file_time + delta
         for variable in variables:
             options["variable"] = variable
-            options_copy = dict(options)
             aggregation_entries = _get_aggregation_entries(options)
             aggregation_types = [
                 agg_entry.get("aggregation") for agg_entry in aggregation_entries
@@ -580,6 +579,7 @@ def get_gridded_files(
                 entry = dc.get_catalog_entry(options)
                 aggregation_entries = [entry] if entry else []
             for entry in aggregation_entries:
+                options_copy = dict(options)
                 if entry is None:
                     raise ValueError("No data catalog entry found for options.")
                 aggregation = entry.get("aggregation")
@@ -1296,7 +1296,7 @@ def _apply_mask(data, entry, options):
                 "grid": grid,
                 "grid_bounds": bbox,
                 "level": level,
-                "dataset_version": os.getenv("HUC_VERSION", "")
+                "dataset_version": os.getenv("HUC_VERSION", ""),
             }
         )
         # Apply the HUC mask to the data, mask with all huc_ids
@@ -1311,7 +1311,7 @@ def _apply_mask(data, entry, options):
                 "grid": grid,
                 "grid_bounds": grid_bounds,
                 "level": 2,
-                "dataset_version": os.getenv("HUC_VERSION", "")
+                "dataset_version": os.getenv("HUC_VERSION", ""),
             }
         )
         data = np.where(mask > 0, data, np.nan)
@@ -2087,7 +2087,7 @@ def __get_geotiff(grid: str, level: int) -> xr.Dataset:
         "variable": "huc_map",
         "grid": grid,
         "level": str(level),
-        "dataset_version": os.getenv("HUC_VERSION", "")
+        "dataset_version": os.getenv("HUC_VERSION", ""),
     }
     entry = dc.get_catalog_entry(options)
     if entry is None:
@@ -2704,6 +2704,7 @@ def _get_grid_bounds(grid: str, options: dict) -> List[float]:
         huc_id_list = huc_id.split(",")
         grid_bounds = get_huc_bbox(grid, huc_id_list)
     return grid_bounds
+
 
 class _FileDownloadState:
     """State information about the state of the get_gridded_files() method during thread execution."""

--- a/src/hf_hydrodata/point.py
+++ b/src/hf_hydrodata/point.py
@@ -2228,7 +2228,7 @@ def _get_huc_query(options, param_list, conn, dataset=None, variable=None):
             "grid": grid,
             "file_type": "tiff",
             "level": level,
-            "dataset_version": os.getenv("HUC_VERSION", "")
+            "dataset_version": os.getenv("HUC_VERSION", None)
         }
     )
     conus_huc_mask = np.isin(conus_hucs, hucs).squeeze()

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -2161,7 +2161,8 @@ def test_huc_box_dataset_version():
         bbox = hf.get_huc_bbox("conus2", ["15020018"])
 
     # Test that we can get the bbox using the latest HUC version
-    os.environ["HUC_VERSION"] = ""
+    if os.getenv("HUC_VERSION"):
+        del os.environ["HUC_VERSION"]
     bbox = hf.get_huc_bbox("conus2", ["15020018"])
     assert bbox == [928, 1330, 1061, 1422]
 
@@ -2175,4 +2176,4 @@ def test_latest_huc_version():
         grid="conus2",
         level=4,
     )
-    assert entry["dataset_version"] == ""
+    assert entry["dataset_version"] == "2025_07"

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -2164,3 +2164,15 @@ def test_huc_box_dataset_version():
     os.environ["HUC_VERSION"] = ""
     bbox = hf.get_huc_bbox("conus2", ["15020018"])
     assert bbox == [928, 1330, 1061, 1422]
+
+def test_latest_huc_version():
+    """Test that getting huc_mapping without dataset_version returns the default blank dataset version."""
+
+    entry = hf.get_catalog_entry(
+        dataset="huc_mapping",
+        file_type="tiff",
+        variable="huc_map",
+        grid="conus2",
+        level=4,
+    )
+    assert entry["dataset_version"] == ""

--- a/utils/public_release.ddl
+++ b/utils/public_release.ddl
@@ -23,7 +23,7 @@ DELETE FROM public.site_type;
 DELETE FROM public.structure_type;
 DELETE FROM public.substitution_keys;
 
-INSERT INTO public.dataset_version SELECT * from development.datset_version;
+INSERT INTO public.dataset_version SELECT * from development.dataset_version;
 INSERT INTO public.unit_type SELECT * from development.unit_type;
 INSERT INTO public.units SELECT * from development.units;
 INSERT INTO public.variable_type SELECT * from development.variable_type;

--- a/utils/public_release.ddl
+++ b/utils/public_release.ddl
@@ -7,6 +7,7 @@ SELECT id, dataset_start_date, dataset_end_date INTO public.dataset_dates FROM p
 
 DELETE FROM public.data_catalog_entry;
 DELETE FROM public.dataset;
+DELETE FROM public.dataset_version;
 DELETE FROM public.datasource;
 DELETE FROM public.temporal_resolution;
 DELETE FROM public.dataset_type;
@@ -22,6 +23,7 @@ DELETE FROM public.site_type;
 DELETE FROM public.structure_type;
 DELETE FROM public.substitution_keys;
 
+INSERT INTO public.dataset_version SELECT * from development.datset_version;
 INSERT INTO public.unit_type SELECT * from development.unit_type;
 INSERT INTO public.units SELECT * from development.units;
 INSERT INTO public.variable_type SELECT * from development.variable_type;


### PR DESCRIPTION
Fix the preferred value logic for dataset_version to select "" or None or 1.0 as preferred values to make the correct default work for the new huc_mapping dataset_versions. This should fix the failing unit test in subset tools that uses this.

Also fix the race condition issue with reading parallel aggregation files in get_gridded_files().
This was fixed by moving the copy_options variable inside the aggregation loop so the different modified values for different aggregations were not overwritten when multiple aggregations were loaded in parallel.