### PR TITLE
add custom error message during maintenance window

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.35"
+version = "1.3.36"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/data_catalog.py
+++ b/src/hf_hydrodata/data_catalog.py
@@ -9,6 +9,7 @@ from typing import List
 import threading
 import requests
 from hf_hydrodata.data_model_access import ModelTableRow, load_data_model
+from hf_hydrodata.gridded import maintenance_guard
 
 HYDRODATA = "/hydrodata"
 JWT_TOKEN = None
@@ -243,6 +244,7 @@ def get_variables(*args, **kwargs) -> List[str]:
     return result
 
 
+@maintenance_guard
 def get_catalog_entries(*args, **kwargs) -> List[ModelTableRow]:
     """
     Get data catalog entry rows selected by filter options.
@@ -338,6 +340,7 @@ def get_catalog_entries(*args, **kwargs) -> List[ModelTableRow]:
     return result
 
 
+@maintenance_guard
 def get_catalog_entry(*args, **kwargs) -> ModelTableRow:
     """
     Get a single data catalog entry row selected by filter options.

--- a/src/hf_hydrodata/point.py
+++ b/src/hf_hydrodata/point.py
@@ -18,8 +18,13 @@ import pyproj
 from shapely import contains_xy
 from shapely.geometry import Point, shape
 from shapely.ops import transform
-from hf_hydrodata.gridded import get_huc_bbox, get_gridded_data
+from hf_hydrodata.gridded import (
+    get_huc_bbox,
+    get_gridded_data,
+    maintenance_guard,
+)
 from hf_hydrodata.data_catalog import get_catalog_entry
+
 
 HYDRODATA = "/hydrodata"
 DB_PATH = f"{HYDRODATA}/national_obs/point_obs.sqlite"
@@ -60,6 +65,7 @@ SITE_ATTRIBUTE_TABLES = [
 DEPTH_LEVELS = [2, 4, 8, 20, 40]
 
 
+@maintenance_guard
 def get_point_data(*args, **kwargs):
     """
     Collect point observations data into a Pandas DataFrame.
@@ -133,7 +139,7 @@ def get_point_data(*args, **kwargs):
 
     If the environment variable HUC_VERSION is set this will cause the function to use the HUC boundaries for
     that dataset_version when HUC is passed as a option.
-    The versions 2025_06, 2025_01, 2024_11 are supported as well as blank to use the latest HUC boundaries.       
+    The versions 2025_06, 2025_01, 2024_11 are supported as well as blank to use the latest HUC boundaries.
     """
     if len(args) > 0 and isinstance(args[0], dict):
         options = args[0]
@@ -268,6 +274,7 @@ def get_point_data(*args, **kwargs):
     return data_df.reset_index().drop("index", axis=1)
 
 
+@maintenance_guard
 def get_point_metadata(*args, **kwargs):
     """
     Return DataFrame with site metadata for the filtered sites.
@@ -535,6 +542,7 @@ def get_point_metadata(*args, **kwargs):
     return metadata_df
 
 
+@maintenance_guard
 def get_site_variables(*args, **kwargs):
     """
     Return DataFrame with available sites, variables, and the period of record.
@@ -2228,7 +2236,7 @@ def _get_huc_query(options, param_list, conn, dataset=None, variable=None):
             "grid": grid,
             "file_type": "tiff",
             "level": level,
-            "dataset_version": os.getenv("HUC_VERSION", None)
+            "dataset_version": os.getenv("HUC_VERSION", None),
         }
     )
     conus_huc_mask = np.isin(conus_hucs, hucs).squeeze()

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -2166,6 +2166,7 @@ def test_huc_box_dataset_version():
     bbox = hf.get_huc_bbox("conus2", ["15020018"])
     assert bbox == [928, 1330, 1061, 1422]
 
+
 def test_latest_huc_version():
     """Test that getting huc_mapping without dataset_version returns the default blank dataset version."""
 
@@ -2177,3 +2178,42 @@ def test_latest_huc_version():
         level=4,
     )
     assert entry["dataset_version"] == "2025_07"
+
+
+def test_maintenance_error_fail(monkeypatch):
+    """
+    Test MaintenanceError is raised when get_gridded_data raises an Error
+    during the maintenance window.
+    """
+    # Artifically set the maintenance window to always be True
+    monkeypatch.setattr("hf_hydrodata.gridded._is_maintenance_window", lambda: True)
+
+    with pytest.raises(gr.MaintenanceError):
+        gr.get_gridded_data(
+            dataset="dummy", variable="dummy", temporal_resolution="daily"
+        )
+
+
+def test_maintenance_error_pass(monkeypatch):
+    """
+    Test MaintenanceError is not raised when get_gridded_data does
+    not raise an Error, even if it's during the maintenance window.
+    """
+    # Artifically set the maintenance window to always be True
+    monkeypatch.setattr("hf_hydrodata.gridded._is_maintenance_window", lambda: True)
+
+    gr.HYDRODATA = "/hydrodata"
+
+    start_time = datetime.datetime.strptime("2005-09-01", "%Y-%m-%d")
+    end_time = start_time + datetime.timedelta(hours=48)
+    data = gr.get_gridded_data(
+        dataset="NLDAS2",
+        file_type="pfb",
+        period="hourly",
+        variable="precipitation",
+        start_time=start_time,
+        end_time=end_time,
+        grid="conus1",
+        grid_bounds=[1000, 1000, 1005, 1005],
+    )
+    assert data.shape[0] == 48

--- a/tests/hf_hydrodata/test_point.py
+++ b/tests/hf_hydrodata/test_point.py
@@ -11,6 +11,7 @@ import numpy as np
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../src")))
 
 from hf_hydrodata import point
+from hf_hydrodata.gridded import MaintenanceError
 
 REMOTE_TEST_DATA_DIR = "/hydrodata/national_obs/tools/test_data"
 LOCAL_TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "test_data")
@@ -1870,6 +1871,44 @@ def test_depth_level_provided_not_sm():
         str(exc.value)
         == "Parameter depth_level is only supported when variable=='soil_moisture'."
     )
+
+
+def test_maintenance_error_point_fail(monkeypatch):
+    """
+    Test MaintenanceError is raised when get_point_data raises an Error
+    during the maintenance window.
+    """
+    # Artifically set the maintenance window to always be True
+    monkeypatch.setattr("hf_hydrodata.gridded._is_maintenance_window", lambda: True)
+
+    with pytest.raises(MaintenanceError):
+        point.get_point_data(
+            dataset="dummy",
+            variable="dummy",
+            temporal_resolution="daily",
+            aggregation="dummy",
+        )
+
+
+def test_maintenance_error_point_pass(monkeypatch):
+    """
+    Test MaintenanceError is not raised when get_point_data does
+    not raise an Error, even if it's during the maintenance window.
+    """
+    # Artifically set the maintenance window to always be True
+    monkeypatch.setattr("hf_hydrodata.gridded._is_maintenance_window", lambda: True)
+
+    df = point.get_point_data(
+        dataset="usgs_nwis",
+        variable="streamflow",
+        temporal_resolution="daily",
+        aggregation="mean",
+        date_start="2002-01-01",
+        date_end="2002-01-05",
+        latitude_range=(47, 50),
+        longitude_range=(-75, -50),
+    )
+    assert len(df) == 5
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Every month there is cluster maintenance which often results in downtime of our servers. This PR adds a custom MaintenanceError wrapper that displays for users that encounter an error during the timeframe of the monthly maintenance window. The decorator, `maintenance_guard`, is applied to various user-facing functions that would be impacted by this maintenance.