### PR TITLE
specify backend for writing netcdf

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.3.37"
+version = "1.3.38"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -945,7 +945,7 @@ def _execute_dask_items(dask_items, state, file_name: str):
             file_name_dir = os.path.dirname(file_name)
             if file_name_dir and not os.path.exists(file_name_dir):
                 os.makedirs(file_name_dir, exist_ok=True)
-            ds.to_netcdf(file_name, encoding=enc)
+            ds.to_netcdf(file_name, encoding=enc, engine="netcdf4")
 
 
 def _consolate_dask_items(items):


### PR DESCRIPTION
This PR is to fix an error encountered in our regular test suite. This is related to writing of NetCDF files. It appears that this issue is with using the scipy backend for writing files. This PR specifies the backend explicitly to use `engine="netcdf4"`.

```
def test_multiple_aggregations(tmp_path):
        """Test that we can get_gridded_files with multiple aggregations."""
    
        cd = os.getcwd()
        os.chdir(tmp_path)
    
        variables = ["precipitation", "air_temp", "downward_shortwave"]
        bounds = [500, 500, 502, 502]
        start_time = datetime.datetime(1991, 8, 4)
        end_time = start_time + datetime.timedelta(days=2)
        options = {
            "dataset": "CW3E",
            "grid_bounds": bounds,
            "temporal_resolution": "daily",
            "start_time": start_time,
            "end_time": end_time,
        }
        assert not os.path.exists("foo.nc")
>       gr.get_gridded_files(options, variables=variables, filename_template="foo.nc")
```

```self = <xarray.backends.scipy_.ScipyDataStore object at 0x7fd1360af230>
name = 'Temp_min'
variable = <xarray.Variable (time: 365, y: 2, x: 2)> Size: 12kB
array([[[0., 0.],
        [0., 0.]],

       [[0., 0.],
        [...0.],
        [0., 0.]]], shape=(365, 2, 2))
Attributes:
    coordinates:  b'latitude longitude'
    _FillValue:   [nan]
check_encoding = True, unlimited_dims = None

    def prepare_variable(
        self, name, variable, check_encoding=False, unlimited_dims=None
    ):
        if (
            check_encoding
            and variable.encoding
            and variable.encoding != {"_FillValue": None}
        ):
>           raise ValueError(
                f"unexpected encoding for scipy backend: {list(variable.encoding)}"
            )
E           ValueError: unexpected encoding for scipy backend: ['zlib', 'complevel', 'fletcher32', 'chunksizes']
```