### PR TITLE
add new python version to regular testing

### DIFF
--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         # update list with desired Python versions to test
-        python-version: ["3.12"]
+        python-version: ["3.12", "3.14"]
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
This PR adds Python 3.14 to the regular weekly unit testing.