### PR TITLE
Xsend point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.4.5"
+version = "1.4.3"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.4.4"
+version = "1.4.5"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.4.2"
+version = "1.4.4"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/data_catalog.py
+++ b/src/hf_hydrodata/data_catalog.py
@@ -149,15 +149,13 @@ def register_api_pin(email: str, pin: str):
         raise ValueError("Email and PIN are not specified in call to register_api_pin.")
 
     url = f"{HYDRODATA_URL}/api/api_pins?pin={pin}&email={email}"
-    response = requests.get(url, timeout=1200)
+    response = requests.get(url, timeout=20)
     if response.status_code == 400:
         raise ValueError(
             f"This PIN is not registered for '{email}' (expired?). Register a pin with https://hydrogen.princeton.edu/pin. Signup with https://hydrogen.princeton.edu/signup."
         )
     if not response.status_code == 200:
-        raise ValueError(
-            f"Unable to validate '{email}' and PIN. Check if you can register a pin with https://hydrogen.princeton.edu/pin"
-        )
+        raise ValueError(f"Unable to authenticate with your email/pin with '{HYDRODATA_URL}' server.")
     pin_dir = os.path.expanduser("~/.hydrodata")
     os.makedirs(pin_dir, mode=0o700, exist_ok=True)
     pin_path = f"{pin_dir}/pin.json"

--- a/src/hf_hydrodata/data_model_access.py
+++ b/src/hf_hydrodata/data_model_access.py
@@ -21,6 +21,7 @@ Functions to load the csv files of the data catalog model into a DataModel objec
 import os
 import json
 import datetime
+import time
 from typing import Tuple
 import threading
 import platform
@@ -33,6 +34,8 @@ READ_DC_CALLBACK = None
 HYDRODATA = "/hydrodata"
 JWT_TOKEN = None
 USER_ROLES = None
+JWT_TOKEN_CACHE_TIME = 4 * 60   # seconds to cache the JWT_TOKEN
+JWT_TOKEN_TIMESTAMP = None      # timestamp of collected JWT_TOKEN
 
 
 class ModelTableRow:
@@ -204,11 +207,11 @@ def _get_api_headers(required=True) -> dict:
         ValueError if no API key is registered or unable to create a JWT token.
     """
 
+    global JWT_TOKEN_TIMESTAMP
     global JWT_TOKEN
     global USER_ROLES
-    if not JWT_TOKEN:
+    if not JWT_TOKEN or JWT_TOKEN_TIMESTAMP is None or time.time() - JWT_TOKEN_TIMESTAMP > JWT_TOKEN_CACHE_TIME:
         # Only do this if we do not already have a JWT_TOKEN cached in the global variable
-
         if "verde-" in platform.node() and not os.getenv("https_proxy"):
             # This is to configure a proxy for a princeton environment if not already specified
             os.environ["https_proxy"] = "http://verde:8080"
@@ -216,7 +219,10 @@ def _get_api_headers(required=True) -> dict:
         if not required and not email:
             return {}
         url_security = f"{HYDRODATA_URL}/api/api_pins?pin={pin}&email={email}"
-        response = requests.get(url_security, timeout=1200)
+        try:
+            response = requests.get(url_security, timeout=1200)
+        except:
+            raise ValueError(f"Unable to authenticate with your email/pin with '{HYDRODATA_URL}' server.")
         if not response.status_code == 200:
             if not required:
                 # The PIN is not required so it is ok that the API request returned an error.
@@ -235,6 +241,7 @@ def _get_api_headers(required=True) -> dict:
                     "PIN has expired. Re-register a pin with https://hydrogen.princeton.edu/pin . Signup with https://hydrogen.princeton.edu/signup. Register the pin with python by executing 'hf_hydrodata.register_api_pin()'."
                 )
         JWT_TOKEN = jwt_json["jwt_token"]
+        JWT_TOKEN_TIMESTAMP = time.time()
         USER_ROLES = jwt_json.get("user_roles")
 
     headers = {}

--- a/src/hf_hydrodata/data_model_access.py
+++ b/src/hf_hydrodata/data_model_access.py
@@ -221,9 +221,7 @@ def _get_api_headers(required=True) -> dict:
             if not required:
                 # The PIN is not required so it is ok that the API request returned an error.
                 return {}
-            raise ValueError(
-                f"No registered PIN for '{email}' (expired?). Re-register a pin with https://hydrogen.princeton.edu/pin . Signup with https://hydrogen.princeton.edu/signup. Register the pin with python by executing 'hf_hydrodata.register_api_pin()'."
-            )
+            raise ValueError(f"Unable to authenticate with your email/pin with '{HYDRODATA_URL}' server.")
         json_string = response.content.decode("utf-8")
         jwt_json = json.loads(json_string)
         expires_string = jwt_json.get("expires")

--- a/src/hf_hydrodata/grid.py
+++ b/src/hf_hydrodata/grid.py
@@ -93,24 +93,24 @@ def from_latlon(grid: str, *args) -> List[float]:
         raise ValueError(f"No such grid {grid} available.")
     grid_resolution = float(grid_row["resolution_meters"])
     shape = grid_row["shape"]
+    if shape and len(shape) == 3:
+        # Check if x,y points are within the grid bounds
+        bounds_x = float(shape[2])
+        bounds_y = float(shape[1])
+    elif shape and len(shape) == 2:
+        # Check if x,y points are within the grid bounds
+        bounds_x = float(shape[1])
+        bounds_y = float(shape[0])
+    else:
+        raise ValueError(f"Unable to convert lat/lon to grid '{grid}' because grid bounds not available.")
     for index in range(0, len(args), 2):
         lat = args[index]
         lon = args[index + 1]
         (x, y) = to_meters(grid, lat, lon)
         x = x / grid_resolution
         y = y / grid_resolution
-        if shape and len(shape) == 3:
-            # Check if x,y points are within the grid bounds
-            bounds_x = float(shape[2])
-            bounds_y = float(shape[1])
-            x = min(max(x, 0.0), bounds_x)
-            y = min(max(y, 0.0), bounds_y)
-        elif shape and len(shape) == 2:
-            # Check if x,y points are within the grid bounds
-            bounds_x = float(shape[1])
-            bounds_y = float(shape[0])
-            x = min(max(x, 0.0), bounds_x)
-            y = min(max(y, 0.0), bounds_y)
+        x = min(max(x, 0.0), bounds_x)
+        y = min(max(y, 0.0), bounds_y)
         result.append(x)
         result.append(y)
     return result

--- a/src/hf_hydrodata/grid.py
+++ b/src/hf_hydrodata/grid.py
@@ -99,14 +99,18 @@ def from_latlon(grid: str, *args) -> List[float]:
         (x, y) = to_meters(grid, lat, lon)
         x = x / grid_resolution
         y = y / grid_resolution
-        if shape and len(shape) >= 2:
+        if shape and len(shape) == 3:
             # Check if x,y points are within the grid bounds
             bounds_x = float(shape[2])
             bounds_y = float(shape[1])
-            if not (0 <= round(x) <= bounds_x and 0 <= round(y) <= bounds_y):
-                raise ValueError(
-                    f"The lat/lon point maps to {int(x)},{int(y)} which is outside of grid bounds {bounds_x}, {bounds_y}"
-                )
+            x = min(max(x, 0.0), bounds_x)
+            y = min(max(y, 0.0), bounds_y)
+        elif shape and len(shape) == 2:
+            # Check if x,y points are within the grid bounds
+            bounds_x = float(shape[1])
+            bounds_y = float(shape[0])
+            x = min(max(x, 0.0), bounds_x)
+            y = min(max(y, 0.0), bounds_y)
         result.append(x)
         result.append(y)
     return result

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -1082,12 +1082,12 @@ def _construct_string_from_options(qparam_values):
     return result_string
 
 
-def _write_file_from_api(filepath, options):
+def _write_file_from_api(filepath:str, options:dict):
     """Get the hydroframe file that is selected by the options to the given filepath.
 
     Args:
-        filepath:          Either a ModelTableRow or the ID number of a data_catalog_entry. If None use the entry found by the filters.
-        options:           Optional positional parameter that must be a dict with data filter options.
+        filepath:          File path to write the file from the API call.
+        options:           Data catalog filter parameters to identify the file to download.
     Returns:
         None
     Raises:
@@ -1097,7 +1097,8 @@ def _write_file_from_api(filepath, options):
     q_params = _construct_string_from_options(options)
     datafile_url = f"{HYDRODATA_URL}/api/data-file?{q_params}"
     download_start = ""
-
+    headers = None
+    response = None
     try:
         headers = _get_api_headers()
         response = requests.get(datafile_url, headers=headers, timeout=4000)
@@ -1124,13 +1125,22 @@ def _write_file_from_api(filepath, options):
             raise ValueError(message) from None
 
     except requests.exceptions.Timeout:
-        message = "Timeout error from server. Try again later or try to reduce the size of data in the API request using time or space filters."
+        message = "Timeout error from server. Try again later or modify the query."
         _send_download_complete_reply(
             response, headers, download_start, message=message
         )
         raise ValueError(message) from None
     except requests.exceptions.ChunkedEncodingError:
         message = f"The {datafile_url} has timed out. Try again later or change your query."
+        _send_download_complete_reply(
+            response, headers, download_start, message=message
+        )
+        raise ValueError(message) from None
+    except Exception as e:
+        message = str(e)
+        _send_download_complete_reply(
+            response, headers, download_start, message=message
+        )
         raise ValueError(message) from None
 
     content = response.content
@@ -1781,6 +1791,8 @@ def _get_gridded_data_from_api(options):
         q_params = "&".join(options_list)
 
         download_start = ""
+        headers = None
+        response = None
         gridded_data_url = f"{HYDRODATA_URL}/api/gridded-data?{q_params}"
         try:
             headers = _get_api_headers()
@@ -1804,6 +1816,12 @@ def _get_gridded_data_from_api(options):
                     response_json = json.loads(content)
                     message = response_json.get("message")
                     raise ValueError(message)
+                elif response.status_code == 502:
+                    message = f"Server '{HYDRODATA_URL}' unavailable. Try again later."
+                    _send_download_complete_reply(
+                        response, headers, download_start, message=message
+                    )
+                    raise ValueError(message)
                 elif response.status_code != 200:
                     message = f"System error {response.status_code}. Try again later."
                     _send_download_complete_reply(
@@ -1825,6 +1843,9 @@ def _get_gridded_data_from_api(options):
             raise ValueError(message) from te
         except Exception as e:
             message = str(e)
+            _send_download_complete_reply(
+                response, headers, download_start, message=message
+            )
             raise ValueError(message) from e
 
 
@@ -1868,18 +1889,21 @@ def _send_download_complete_reply(
         download_start:     The timestamp when the download started to compute duration for the log.
         message:            The error message of the request or None.
     """
-    headers = response.headers
-    transfer_filename = headers.get("transfer-filename")
-    job_queue_duration = headers.get("queue-job-duration")
-    job_query_parameters = headers.get("query_parameters")
-    message = message.replace(",", " ") if message else ""
-    query_parameters = {
-        "transfer_filename": transfer_filename,
-        "download_start": download_start,
-        "error_message": message,
-        "job_queue_duration": job_queue_duration,
-        "job_query_parameters": job_query_parameters
-    }
+    if response and request_headers:
+        headers = response.headers
+        transfer_filename = headers.get("transfer-filename")
+        job_queue_duration = headers.get("queue-job-duration")
+        job_query_parameters = headers.get("query_parameters")
+        message = message.replace(",", " ") if message else ""
+        query_parameters = {
+            "transfer_filename": transfer_filename,
+            "download_start": download_start,
+            "error_message": message,
+            "job_queue_duration": job_queue_duration,
+            "job_query_parameters": job_query_parameters
+        }
+    else:
+        query_parameters = {"error_message": message}
     query_parameters_string = "&".join(
         [
             key + "=" + query_parameters[key]
@@ -1887,11 +1911,12 @@ def _send_download_complete_reply(
             if query_parameters.get(key)
         ]
     )
-    url = f"{HYDRODATA_URL}/api/gridded-data?{query_parameters_string}"
-    try:
-        requests.delete(url, headers=request_headers, timeout=60)
-    except:
-        pass
+    if request_headers:
+        url = f"{HYDRODATA_URL}/api/gridded-data?{query_parameters_string}"
+        try:
+            requests.delete(url, headers=request_headers, timeout=60)
+        except:
+            pass
 
 
 def _adjust_dimensions(data: np.ndarray, entry: ModelTableRow) -> np.ndarray:

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -3008,6 +3008,8 @@ def _get_grid_bounds(grid: str, options: dict) -> List[float]:
 
     grid_bounds = options.get("grid_bounds")
     grid_point = options.get("grid_point")
+    latitude_range = options.get("latitude_range")
+    longitude_range = options.get("longitude_range")
     latlon_point = (
         options.get("latlon_point")
         if options.get("latlon_point")
@@ -3018,6 +3020,19 @@ def _get_grid_bounds(grid: str, options: dict) -> List[float]:
         if options.get("latlng_bounds")
         else options.get("latlon_bounds")
     )
+    if isinstance(grid_bounds, str):
+       grid_bounds = json.loads(grid_bounds)
+    if isinstance(grid_point, str):
+       grid_point = json.loads(grid_point)
+    if isinstance(latlon_bounds, str):
+       latlon_bounds = json.loads(latlon_bounds)
+    if isinstance(latlon_point, str):
+       latlon_point = json.loads(latlon_point)
+    if isinstance(latitude_range, str):
+       latitude_range = json.loads(latitude_range)
+    if isinstance(longitude_range, str):
+       longitude_range = json.loads(longitude_range)
+
     if grid_point and grid_bounds:
         raise ValueError("Cannot specify both grid_bounds and grid_point")
     if latlon_point:
@@ -3038,9 +3053,15 @@ def _get_grid_bounds(grid: str, options: dict) -> List[float]:
         ]
     if grid_bounds and latlon_bounds:
         raise ValueError("Cannot specify both grid_bounds and latlon_bounds")
+    if latlon_bounds and (latitude_range or longitude_range):
+        raise ValueError("Cannot specify both latlon_bounds and latitude_range and longitude_range")
     if latlon_bounds:
         # Convert to grid_bounds using same algorithm as subset tools
         grid_bounds = _convert_latlon_to_grid(grid, latlon_bounds)
+    if latitude_range and longitude_range:
+        if len(latitude_range) != 2 or len(longitude_range) != 2:
+            raise ValueError("The latitude_range and longitude_range must be length 2 each.")
+        grid_bounds = _convert_latlon_to_grid(grid, [latitude_range[0], longitude_range[0], latitude_range[1], longitude_range[1]])
     huc_id = options.get("huc_id")
     if grid_bounds and huc_id:
         raise ValueError("Cannot specify both grid_bounds, latlon_bounds and huc_id")

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -1806,7 +1806,7 @@ def _get_gridded_data_from_api(options):
                     message = response_json.get("message")
                     raise ValueError(message)
                 elif response.status_code in [500, 502]:
-                    message = f"System error {response.status_code}. Possibly too many download requests in progress. Try again later."
+                    message = f"System error {response.status_code}. Try again later."
                     _send_download_complete_reply(
                         response, headers, download_start, message=message
                     )
@@ -1819,20 +1819,20 @@ def _get_gridded_data_from_api(options):
                     raise ValueError(message)
 
         except requests.exceptions.ChunkedEncodingError as ce:
-            message = "Chunked encoding error from server. Try again later or try to reduce the size of data in the API request using time or space filters."
+            message = "Chunked encoding error from server. Try again later or modify query."
             _send_download_complete_reply(
                 response, headers, download_start, message=message
             )
             raise ValueError(message) from ce
         except requests.exceptions.Timeout as te:
-            message = "Timeout error from server. Try again later or try to reduce the size of data in the API request using time or space filters."
+            message = "Timeout error from server. Try again later or modify query."
             _send_download_complete_reply(
                 response, headers, download_start, message=message
             )
             raise ValueError(message) from te
         content = response.content
         if content is None or len(content) == 0:
-            message = "Empty content from server. Try again later or try to reduce the size of data in the API request using time or space filters."
+            message = "Empty content from server. Try again later or modify query."
             _send_download_complete_reply(
                 response, headers, download_start, message=message
             )

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -1112,12 +1112,12 @@ def _write_file_from_api(filepath, options):
                 )
                 raise ValueError(message)
             if response.status_code == 502:
-                message = "Timeout error from server. Try again later or try to reduce the size of data in the API request using time or space filters."
+                message = "Server '%s' is not responding. Try again later."
                 _send_download_complete_reply(
                     response, headers, download_start, message=message
                 )
                 raise ValueError(message) from None
-            message = f"The {datafile_url} returned error code {response.status_code}."
+            message = f"The {HYDRODATA_URL} returned error code {response.status_code}."
             _send_download_complete_reply(
                 response, headers, download_start, message=message
             )
@@ -1130,18 +1130,22 @@ def _write_file_from_api(filepath, options):
         )
         raise ValueError(message) from None
     except requests.exceptions.ChunkedEncodingError:
-        message = f"The {datafile_url} has timed out. Try again later or try to reduce the size of data in the API request using time or space filters."
+        message = f"The {datafile_url} has timed out. Try again later or change your query."
         raise ValueError(message) from None
 
     content = response.content
     if content is None or len(content) == 0:
-        message = "Timeout response from server. Try again later or try to reduce the size of data in the API request using time or space filters."
+        message = "No content returned from server. Try again later or change your query."
         _send_download_complete_reply(
             response, headers, download_start, message=message
         )
         raise ValueError(message) from None
 
     # The response was successful
+    updated_download_start = response.headers.get("download-start")
+    download_start = (
+        updated_download_start if updated_download_start else download_start
+    )
     _send_download_complete_reply(response, headers, download_start)
     file_obj = io.BytesIO(content)
     with open(filepath, "wb") as output_file:
@@ -1869,12 +1873,14 @@ def _send_download_complete_reply(
     headers = response.headers
     transfer_filename = headers.get("transfer-filename")
     job_queue_duration = headers.get("queue-job-duration")
+    job_query_parameters = headers.get("query_parameters")
     message = message.replace(",", " ") if message else ""
     query_parameters = {
         "transfer_filename": transfer_filename,
         "download_start": download_start,
         "error_message": message,
         "job_queue_duration": job_queue_duration,
+        "job_query_parameters": job_query_parameters
     }
     query_parameters_string = "&".join(
         [

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -3030,9 +3030,15 @@ def _get_grid_bounds(grid: str, options: dict) -> List[float]:
     if isinstance(latlon_point, str):
        latlon_point = json.loads(latlon_point)
     if isinstance(latitude_range, str):
-       latitude_range = ast.literal_eval(latitude_range)
+        if latitude_range.strip().startswith("("):
+            latitude_range = ast.literal_eval(latitude_range)
+        else:
+            latitude_range = json.loads(latitude_range)
     if isinstance(longitude_range, str):
-       longitude_range = ast.literal_eval(longitude_range)
+        if longitude_range.strip().startswith("("):
+            longitude_range = ast.literal_eval(longitude_range)
+        else:
+            longitude_range = json.loads(longitude_range)
     if grid_point and grid_bounds:
         raise ValueError("Cannot specify both grid_bounds and grid_point")
     if latlon_point:

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -7,6 +7,7 @@ import os
 import datetime
 import time
 import io
+import ast
 from typing import List, Tuple
 import json
 import shutil
@@ -3029,10 +3030,9 @@ def _get_grid_bounds(grid: str, options: dict) -> List[float]:
     if isinstance(latlon_point, str):
        latlon_point = json.loads(latlon_point)
     if isinstance(latitude_range, str):
-       latitude_range = json.loads(latitude_range)
+       latitude_range = ast.literal_eval(latitude_range)
     if isinstance(longitude_range, str):
-       longitude_range = json.loads(longitude_range)
-
+       longitude_range = ast.literal_eval(longitude_range)
     if grid_point and grid_bounds:
         raise ValueError("Cannot specify both grid_bounds and grid_point")
     if latlon_point:

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -1770,7 +1770,6 @@ def _get_gridded_data_from_api(options):
     numpy array of the requested data or None if running locally.
     """
     run_remote = not os.path.exists(HYDRODATA)
-
     if run_remote:
         if options.get("period") and not options.get("temporal_resolution"):
             options["period"] = options["temporal_resolution"]
@@ -1805,14 +1804,8 @@ def _get_gridded_data_from_api(options):
                     response_json = json.loads(content)
                     message = response_json.get("message")
                     raise ValueError(message)
-                elif response.status_code in [500, 502]:
-                    message = f"System error {response.status_code}. Try again later."
-                    _send_download_complete_reply(
-                        response, headers, download_start, message=message
-                    )
-                    raise ValueError(message)
                 elif response.status_code != 200:
-                    message = f"The {gridded_data_url} returned error code {response.status_code}."
+                    message = f"System error {response.status_code}. Try again later."
                     _send_download_complete_reply(
                         response, headers, download_start, message=message
                     )
@@ -1830,6 +1823,11 @@ def _get_gridded_data_from_api(options):
                 response, headers, download_start, message=message
             )
             raise ValueError(message) from te
+        except Exception as e:
+            message = str(e)
+            raise ValueError(message) from e
+
+
         content = response.content
         if content is None or len(content) == 0:
             message = "Empty content from server. Try again later or modify query."

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -3069,6 +3069,8 @@ def _get_grid_bounds(grid: str, options: dict) -> List[float]:
             raise ValueError("The latitude_range and longitude_range must be length 2 each.")
         grid_bounds = _convert_latlon_to_grid(grid, [latitude_range[0], longitude_range[0], latitude_range[1], longitude_range[1]])
     huc_id = options.get("huc_id")
+    if huc_id and isinstance(huc_id, str) and huc_id.startswith("["):
+        huc_id = json.loads(huc_id)
     if grid_bounds and huc_id:
         raise ValueError("Cannot specify both grid_bounds, latlon_bounds and huc_id")
     if huc_id and grid in ["conus1", "conus2"]:

--- a/src/hf_hydrodata/point.py
+++ b/src/hf_hydrodata/point.py
@@ -988,9 +988,6 @@ def _get_siteid_data_from_api(options):
         raise ValueError(message)
     except Exception as e:
         message = f"The remote get_site_variables has has failed with: {str(e)}"
-        _send_download_complete_reply(
-            response, headers, "site-variables-dataframe", download_start, message=message
-        )
         raise ValueError(message)
 
     updated_download_start = response.headers.get("download-start")
@@ -1034,12 +1031,16 @@ def _get_data_from_api(data_type, options):
                     message = response_json.get("message")
                     raise ValueError(message)
                 if response.status_code == 502:
-                    raise ValueError(
-                        "Server not available error. Try again later."
+                    message = "Server not available error. Try again later."
+                    _send_download_complete_reply(
+                        response, headers, "point-data-dataframe", download_start, message=message
                     )
-                raise ValueError(
-                    f"The  {point_data_url} returned error code {response.status_code}."
+                    raise ValueError(message)
+                message = f"Server error {response.status_code}. Try again later."
+                _send_download_complete_reply(
+                    response, headers, "point-data-dataframe", download_start, message=message
                 )
+                raise ValueError(message)
     except requests.exceptions.ChunkedEncodingError as ce:
         message = "Chunking error from server. Try again later or modify query."
         _send_download_complete_reply(

--- a/src/hf_hydrodata/point.py
+++ b/src/hf_hydrodata/point.py
@@ -1,12 +1,13 @@
 """Module to retrieve point observations."""
 
-# pylint: disable=C0301,W0707,W0719,C0121,C0302,C0209,C0325,W0702
+# pylint: disable=C0301,W0707,W0719,C0121,C0302,C0209,C0325,W0702,R0912,R0914
 import datetime
 from typing import Tuple
 import io
 import ast
 import os
 import json
+import time
 import sqlite3
 import warnings
 import pandas as pd
@@ -165,6 +166,8 @@ def get_point_data(*args, **kwargs):
 
     run_remote = not os.path.exists(HYDRODATA)
 
+    polygon = None
+    polygon_crs = None
     if run_remote:
         # Cannot pass local shapefile to API; pass bounding box instead
         if "polygon" in options and options["polygon"] is not None:
@@ -359,7 +362,9 @@ def get_point_metadata(*args, **kwargs):
             )
 
     run_remote = not os.path.exists(HYDRODATA)
-
+    polygon = None
+    polygon_crs = None
+    
     if run_remote:
         # Cannot pass local shapefile to API; pass bounding box instead
         if "polygon" in options and options["polygon"] is not None:
@@ -945,12 +950,46 @@ def _get_siteid_data_from_api(options):
     try:
         headers = _validate_user()
         response = requests.get(point_data_url, headers=headers, timeout=180)
+        response_headers = response.headers
+        download_start = response_headers.get("download-start")
+        for retry_count in range(0, 60):
+            # Retry up to 80 times if the response is a 202 (retry) response
+            if response.status_code == 202:
+                # Retry
+                retry_location = response_headers.get("Location")
+                retry_url = f"{HYDRODATA_URL}/api{retry_location}?download_start={download_start}"
+                response = requests.get(retry_url, headers=headers, timeout=10)
+                sleep_duration = 1 if retry_count < 10 else 2 if retry_count < 30 else 4
+                time.sleep(sleep_duration)
+        
+        if response.status_code == 400:
+            # Do not send response for 400 errors because it was already logged
+            message = f"{response.content}."
+            raise ValueError(message)
         if response.status_code != 200:
-            raise ValueError(f"{response.content}.")
+            # send a response for any other non-200 error to log the error
+            message = f"{response.content}."
+            _send_download_complete_reply(
+                response, headers, "site-variables-dataframe", download_start, message=message
+            )
+            raise ValueError(message)
 
-    except requests.exceptions.Timeout as e:
-        raise ValueError(f"The point_data_url {point_data_url} has timed out.") from e
+    except requests.exceptions.Timeout as te:
+        message = f"The remote get_site_variables has timed out."
+        _send_download_complete_reply(
+            response, headers, "site-variables-dataframe", download_start, message=message
+        )
+        raise ValueError(message)
+    except Exception as e:
+        message = f"The remote get_site_variables has has failed with: {str(e)}"
+        _send_download_complete_reply(
+            response, headers, "site-variables-dataframe", download_start, message=message
+        )
+        raise ValueError(message)
 
+    _send_download_complete_reply(
+        response, headers, "site-variables-dataframe", download_start, message=message
+    )
     data_df = pd.read_pickle(io.BytesIO(response.content))
     return data_df
 
@@ -964,29 +1003,49 @@ def _get_data_from_api(data_type, options):
 
     try:
         headers = _validate_user()
-        response = requests.get(point_data_url, headers=headers, timeout=180)
-        if response.status_code != 200:
-            if response.status_code == 400:
-                content = response.content.decode()
-                response_json = json.loads(content)
-                message = response_json.get("message")
-                raise ValueError(message)
-            if response.status_code == 502:
-                raise ValueError(
-                    "Timeout error from server. Try again later or try to reduce the size of data in the API request using time or space filters."
-                )
-            raise ValueError(
-                f"The  {point_data_url} returned error code {response.status_code}."
-            )
-    except requests.exceptions.ChunkedEncodingError as ce:
-        raise ValueError(
-            "Timeout error from server. Try again later or try to reduce the size of data in the API request using time or space filters."
-        ) from ce
-    except requests.exceptions.Timeout as te:
-        raise ValueError(
-            "Timeout error from server. Try again later or try to reduce the size of data in the API request using time or space filters."
-        ) from te
 
+        response = requests.get(point_data_url, headers=headers, timeout=180)
+        response_headers = response.headers
+        download_start = response_headers.get("download-start")
+        for retry_count in range(0, 60):
+            # Retry up to 80 times if the response is a 202 (retry) response
+            if response.status_code == 202:
+                # Retry
+                retry_location = response_headers.get("Location")
+                retry_url = f"{HYDRODATA_URL}/api{retry_location}?download_start={download_start}"
+                response = requests.get(retry_url, headers=headers, timeout=10)
+                sleep_duration = 1 if retry_count < 10 else 2 if retry_count < 30 else 4
+                time.sleep(sleep_duration)
+            elif response.status_code != 200:
+                if response.status_code == 400:
+                    content = response.content.decode()
+                    response_json = json.loads(content)
+                    message = response_json.get("message")
+                    raise ValueError(message)
+                if response.status_code == 502:
+                    raise ValueError(
+                        "Timeout error from server. Try again later or try to reduce the size of data in the API request using time or space filters."
+                    )
+                raise ValueError(
+                    f"The  {point_data_url} returned error code {response.status_code}."
+                )
+    except requests.exceptions.ChunkedEncodingError as ce:
+        message = "Chunking error from server. Try again later or try to reduce the size of data in the API request using time or space filters."
+        _send_download_complete_reply(
+            response, headers, "point-data-dataframe", download_start, message=message
+        )
+        raise ValueError(message)
+    except requests.exceptions.Timeout as te:
+        message = "Timeout error from server. Try again later or try to reduce the size of data in the API request using time or space filters."
+        _send_download_complete_reply(
+            response, headers, "point-data-dataframe", download_start, message=message
+        )
+
+        raise ValueError(message)
+
+    _send_download_complete_reply(
+        response, headers, "point-data-dataframe", download_start
+    )
     data_df = pd.read_pickle(io.BytesIO(response.content))
     return data_df
 
@@ -2299,3 +2358,38 @@ def _get_huc_query(options, param_list, conn, dataset=None, variable=None):
         raise Exception("There are no sites within the provided huc_id.")
 
     return huc_query, param_list
+
+
+def _send_download_complete_reply(
+    response, request_headers, route_name, download_start, message=None
+):
+    """
+    Send back to the API a download complete reply.
+    Parameters:
+        response:           The response returned from a download API call.
+        request_headers:    The request headers with the JWT token to make the new request.
+        download_start:     The timestamp when the download started to compute duration for the log.
+        message:            The error message of the request or None.
+    """
+    headers = response.headers
+    transfer_filename = headers.get("transfer-filename")
+    job_queue_duration = headers.get("queue-job-duration")
+    message = message.replace(",", " ") if message else ""
+    query_parameters = {
+        "transfer_filename": transfer_filename,
+        "download_start": download_start,
+        "error_message": message,
+        "job_queue_duration": job_queue_duration,
+    }
+    query_parameters_string = "&".join(
+        [
+            key + "=" + query_parameters[key]
+            for key in query_parameters
+            if query_parameters.get(key)
+        ]
+    )
+    url = f"{HYDRODATA_URL}/api/{route_name}?{query_parameters_string}"
+    try:
+        requests.delete(url, headers=request_headers, timeout=60)
+    except:
+        pass

--- a/src/hf_hydrodata/point.py
+++ b/src/hf_hydrodata/point.py
@@ -366,7 +366,7 @@ def get_point_metadata(*args, **kwargs):
     run_remote = not os.path.exists(HYDRODATA)
     polygon = None
     polygon_crs = None
-    
+
     if run_remote:
         # Cannot pass local shapefile to API; pass bounding box instead
         if "polygon" in options and options["polygon"] is not None:
@@ -950,7 +950,9 @@ def _get_siteid_data_from_api(options):
     hf_hydrodata_version = importlib.metadata.version("hf_hydrodata")
 
     point_data_url = f"{HYDRODATA_URL}/api/site-variables-dataframe?{q_params}&hf_version={hf_hydrodata_version}"
-
+    headers = None
+    response = None
+    download_start = None
     try:
         headers = _validate_user()
         response = requests.get(point_data_url, headers=headers, timeout=180)
@@ -965,7 +967,7 @@ def _get_siteid_data_from_api(options):
                 response = requests.get(retry_url, headers=headers, timeout=10)
                 sleep_duration = 1 if retry_count < 10 else 2 if retry_count < 30 else 4
                 time.sleep(sleep_duration)
-        
+
         if response.status_code == 400:
             # Do not send response for 400 errors because it was already logged
             content = response.content.decode()
@@ -987,7 +989,10 @@ def _get_siteid_data_from_api(options):
         )
         raise ValueError(message)
     except Exception as e:
-        message = f"The remote get_site_variables has has failed with: {str(e)}"
+        message = f"The remote get_site_variables has failed with: {str(e)}"
+        _send_download_complete_reply(
+            response, headers, "site-variables-dataframe", download_start, message=message
+        )
         raise ValueError(message)
 
     updated_download_start = response.headers.get("download-start")
@@ -1009,9 +1014,11 @@ def _get_data_from_api(data_type, options):
 
     point_data_url = f"{HYDRODATA_URL}/api/point-data-dataframe?{q_params}&hf_version={hf_hydrodata_version}"
 
+    response = None
+    headers = None
+    download_start = None
     try:
         headers = _validate_user()
-
         response = requests.get(point_data_url, headers=headers, timeout=180)
         response_headers = response.headers
         download_start = response_headers.get("download-start")
@@ -1052,7 +1059,12 @@ def _get_data_from_api(data_type, options):
         _send_download_complete_reply(
             response, headers, "point-data-dataframe", download_start, message=message
         )
-
+        raise ValueError(message)
+    except Exception as e:
+        message = str(e)
+        _send_download_complete_reply(
+            response, headers, "point-data-dataframe", download_start, message=message
+        )
         raise ValueError(message)
 
     updated_download_start = response.headers.get("download-start")
@@ -2386,30 +2398,36 @@ def _send_download_complete_reply(
     Parameters:
         response:           The response returned from a download API call.
         request_headers:    The request headers with the JWT token to make the new request.
+        route_name:         The /api/route to use to send back the reply
         download_start:     The timestamp when the download started to compute duration for the log.
         message:            The error message of the request or None.
     """
-    headers = response.headers
-    transfer_filename = headers.get("transfer-filename")
-    job_queue_duration = headers.get("queue-job-duration")
-    job_query_parameters = headers.get("query_parameters")
-    message = message.replace(",", " ") if message else ""
-    query_parameters = {
-        "transfer_filename": transfer_filename,
-        "download_start": download_start,
-        "error_message": message,
-        "job_queue_duration": job_queue_duration,
-        "job_query_parameters": job_query_parameters
-    }
-    query_parameters_string = "&".join(
-        [
-            key + "=" + query_parameters[key]
-            for key in query_parameters
-            if query_parameters.get(key)
-        ]
-    )
-    url = f"{HYDRODATA_URL}/api/{route_name}?{query_parameters_string}"
-    try:
-        requests.delete(url, headers=request_headers, timeout=60)
-    except:
-        pass
+    if response and request_headers:
+        headers = response.headers
+        transfer_filename = headers.get("transfer-filename")
+        job_queue_duration = headers.get("queue-job-duration")
+        job_query_parameters = headers.get("query_parameters")
+        message = message.replace(",", " ") if message else ""
+        query_parameters = {
+            "transfer_filename": transfer_filename,
+            "download_start": download_start,
+            "error_message": message,
+            "job_queue_duration": job_queue_duration,
+            "job_query_parameters": job_query_parameters
+        }
+    else:
+        query_parameters = {"error_message": message}
+
+    if request_headers:
+        query_parameters_string = "&".join(
+            [
+                key + "=" + query_parameters[key]
+                for key in query_parameters
+                if query_parameters.get(key)
+            ]
+        )
+        url = f"{HYDRODATA_URL}/api/{route_name}?{query_parameters_string}"
+        try:
+            requests.delete(url, headers=request_headers, timeout=60)
+        except:
+            pass

--- a/src/hf_hydrodata/point.py
+++ b/src/hf_hydrodata/point.py
@@ -2387,6 +2387,7 @@ def _send_download_complete_reply(
     headers = response.headers
     transfer_filename = headers.get("transfer-filename")
     job_queue_duration = headers.get("queue-job-duration")
+    job_query_parameters = headers.get("query_parameters")
     message = message.replace(",", " ") if message else ""
     query_parameters = {
         "transfer_filename": transfer_filename,
@@ -2402,6 +2403,8 @@ def _send_download_complete_reply(
         ]
     )
     url = f"{HYDRODATA_URL}/api/{route_name}?{query_parameters_string}"
+    request_headers = request_headers.copy()
+    request_headers["query_parameters"] = job_query_parameters
     try:
         requests.delete(url, headers=request_headers, timeout=60)
     except:

--- a/src/hf_hydrodata/point.py
+++ b/src/hf_hydrodata/point.py
@@ -2394,6 +2394,7 @@ def _send_download_complete_reply(
         "download_start": download_start,
         "error_message": message,
         "job_queue_duration": job_queue_duration,
+        "job_query_parameters": job_query_parameters
     }
     query_parameters_string = "&".join(
         [
@@ -2403,8 +2404,6 @@ def _send_download_complete_reply(
         ]
     )
     url = f"{HYDRODATA_URL}/api/{route_name}?{query_parameters_string}"
-    request_headers = request_headers.copy()
-    request_headers["query_parameters"] = job_query_parameters
     try:
         requests.delete(url, headers=request_headers, timeout=60)
     except:

--- a/src/hf_hydrodata/point.py
+++ b/src/hf_hydrodata/point.py
@@ -1035,19 +1035,19 @@ def _get_data_from_api(data_type, options):
                     raise ValueError(message)
                 if response.status_code == 502:
                     raise ValueError(
-                        "Timeout error from server. Try again later or try to reduce the size of data in the API request using time or space filters."
+                        "Server not available error. Try again later."
                     )
                 raise ValueError(
                     f"The  {point_data_url} returned error code {response.status_code}."
                 )
     except requests.exceptions.ChunkedEncodingError as ce:
-        message = "Chunking error from server. Try again later or try to reduce the size of data in the API request using time or space filters."
+        message = "Chunking error from server. Try again later or modify query."
         _send_download_complete_reply(
             response, headers, "point-data-dataframe", download_start, message=message
         )
         raise ValueError(message)
     except requests.exceptions.Timeout as te:
-        message = "Timeout error from server. Try again later or try to reduce the size of data in the API request using time or space filters."
+        message = "Timeout error from server. Try again later or modify query."
         _send_download_complete_reply(
             response, headers, "point-data-dataframe", download_start, message=message
         )
@@ -1233,30 +1233,32 @@ def _construct_string_from_qparams(data_type, options):
 
 
 def _validate_user():
-    email, pin = _get_registered_api_pin()
-    url_security = f"{HYDRODATA_URL}/api/api_pins?pin={pin}&email={email}"
-    response = requests.get(url_security, headers=None, timeout=15)
-    if not response.status_code == 200:
-        raise ValueError(
-            f"PIN has expired. Re-register a pin for '{email}' with https://hydrogen.princeton.edu/pin ."
-        )
-    json_string = response.content.decode("utf-8")
-    jwt_json = json.loads(json_string)
-    expires_string = jwt_json.get("expires")
-    if expires_string:
-        expires = datetime.datetime.strptime(
-            expires_string, "%Y/%m/%d %H:%M:%S GMT-0000"
-        )
-        now = datetime.datetime.now()
-        if now > expires:
+    try:
+        email, pin = _get_registered_api_pin()
+        url_security = f"{HYDRODATA_URL}/api/api_pins?pin={pin}&email={email}"
+        response = requests.get(url_security, headers=None, timeout=15)
+        if not response.status_code == 200:
             raise ValueError(
-                "PIN has expired. Please re-register it from https://hydrogen.princeton.edu/pin"
+                f"PIN has expired. Re-register a pin for '{email}' with https://hydrogen.princeton.edu/pin ."
             )
-    jwt_token = jwt_json["jwt_token"]
-    headers = {}
-    headers["Authorization"] = f"Bearer {jwt_token}"
-    return headers
-
+        json_string = response.content.decode("utf-8")
+        jwt_json = json.loads(json_string)
+        expires_string = jwt_json.get("expires")
+        if expires_string:
+            expires = datetime.datetime.strptime(
+                expires_string, "%Y/%m/%d %H:%M:%S GMT-0000"
+            )
+            now = datetime.datetime.now()
+            if now > expires:
+                raise ValueError(
+                    "PIN has expired. Please re-register it from https://hydrogen.princeton.edu/pin"
+                )
+        jwt_token = jwt_json["jwt_token"]
+        headers = {}
+        headers["Authorization"] = f"Bearer {jwt_token}"
+        return headers
+    except:
+        raise ValueError(f"Unable to authenticate with your email/pin with '{HYDRODATA_URL}' server.")
 
 def _get_variables(conn):
     """

--- a/src/hf_hydrodata/point.py
+++ b/src/hf_hydrodata/point.py
@@ -968,7 +968,9 @@ def _get_siteid_data_from_api(options):
         
         if response.status_code == 400:
             # Do not send response for 400 errors because it was already logged
-            message = f"{response.content}."
+            content = response.content.decode()
+            response_json = json.loads(content)
+            message = response_json.get("message")
             raise ValueError(message)
         if response.status_code != 200:
             # send a response for any other non-200 error to log the error

--- a/src/hf_hydrodata/point.py
+++ b/src/hf_hydrodata/point.py
@@ -991,8 +991,12 @@ def _get_siteid_data_from_api(options):
         )
         raise ValueError(message)
 
+    updated_download_start = response.headers.get("download-start")
+    download_start = (
+        updated_download_start if updated_download_start else download_start
+    )
     _send_download_complete_reply(
-        response, headers, "site-variables-dataframe", download_start, message=message
+        response, headers, "site-variables-dataframe", download_start
     )
     data_df = pd.read_pickle(io.BytesIO(response.content))
     return data_df
@@ -1048,6 +1052,10 @@ def _get_data_from_api(data_type, options):
 
         raise ValueError(message)
 
+    updated_download_start = response.headers.get("download-start")
+    download_start = (
+        updated_download_start if updated_download_start else download_start
+    )
     _send_download_complete_reply(
         response, headers, "point-data-dataframe", download_start
     )

--- a/src/hf_hydrodata/point.py
+++ b/src/hf_hydrodata/point.py
@@ -7,6 +7,7 @@ import io
 import ast
 import os
 import json
+import importlib.metadata
 import time
 import sqlite3
 import warnings
@@ -51,6 +52,7 @@ SUPPORTED_FILTERS = [
     "grid",
     "grid_bounds",
     "huc_id",
+    "hf_version"
 ]
 
 # List of SQL tables in the database corresponding to site-type-specific attributes
@@ -945,7 +947,9 @@ def _get_siteid_data_from_api(options):
 
     q_params = _construct_siteids_string_from_qparams(options)
 
-    point_data_url = f"{HYDRODATA_URL}/api/site-variables-dataframe?{q_params}"
+    hf_hydrodata_version = importlib.metadata.version("hf_hydrodata")
+
+    point_data_url = f"{HYDRODATA_URL}/api/site-variables-dataframe?{q_params}&hf_version={hf_hydrodata_version}"
 
     try:
         headers = _validate_user()
@@ -998,8 +1002,9 @@ def _get_data_from_api(data_type, options):
     options = _convert_params_to_string_dict(options)
 
     q_params = _construct_string_from_qparams(data_type, options)
+    hf_hydrodata_version = importlib.metadata.version("hf_hydrodata")
 
-    point_data_url = f"{HYDRODATA_URL}/api/point-data-dataframe?{q_params}"
+    point_data_url = f"{HYDRODATA_URL}/api/point-data-dataframe?{q_params}&hf_version={hf_hydrodata_version}"
 
     try:
         headers = _validate_user()

--- a/tests/hf_hydrodata/test_grid.py
+++ b/tests/hf_hydrodata/test_grid.py
@@ -12,6 +12,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../s
 
 import hf_hydrodata.grid
 
+
 def test_grid_to_latlng():
     """Test grid_to_latlng."""
 
@@ -64,6 +65,7 @@ def test_latlng_to_grid():
     assert x2 == 487
     assert y2 == 329
 
+
 def test_meters_to_ij():
     """Unit test the meters_to_ij() and to_meters() functions."""
 
@@ -80,22 +82,31 @@ def test_meters_to_ij():
     assert round(x) == 10
     assert round(y) == 10
 
+
 def test_latlng_to_grid_out_of_bounds():
     """Unit tests for when latlng is out of bounds of conus1."""
 
-    with pytest.raises(ValueError):
-        (_, y) = hf_hydrodata.grid.from_latlon("conus1", 90, -180)
-
+    (x, y) = hf_hydrodata.grid.from_latlon("conus1", 50, -61)
+    assert x == pytest.approx(3342)
+    assert y == pytest.approx(1888)
+    (x, y) = hf_hydrodata.grid.from_latlon("conus1", 20, -132)
+    assert x == pytest.approx(0.0)
+    assert y == pytest.approx(0.0)
     (lat, lon) = hf_hydrodata.grid.to_latlon("conus1", 0, 0)
-    (_, _) = hf_hydrodata.grid.to_ij("conus1", lat, lon)
-    with pytest.raises(ValueError):
-        (_, _) = hf_hydrodata.grid.to_ij("conus1", lat, lon+0.025)
+    (x, y) = hf_hydrodata.grid.to_ij("conus1", lat, lon)
+    assert x == 0
+    assert y == 0
+    (x, y) = hf_hydrodata.grid.to_ij("conus1", lat - 2, lon - 2)
+    assert x == 0
+    assert y == 0
+
 
 def test_illegal_grid():
     """Unit test for unknown grid."""
 
     with pytest.raises(ValueError):
         hf_hydrodata.grid.to_ij("conusxxx", 0, 0)
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -869,8 +869,9 @@ def test_latlng_to_grid_out_of_bounds():
     """Unit tests for when latlng is out of bounds of conus1."""
 
     gr.HYDRODATA = "/hydrodata"
-    with pytest.raises(ValueError):
-        (_, _) = hf.from_latlon("conus1", 90, -180)
+    (x, y) = hf.from_latlon("conus1", 50, -61)
+    assert x == pytest.approx(3342)
+    assert y == pytest.approx(1888)
 
 
 def test_gridded_data_no_entry_passed():


### PR DESCRIPTION
Add support for using x_sendfile and queues with get_point_data and get_site_variables.
Added support to pass the query parameters to the delete call after downloading to be able to log the query parameters from the original request to the download entry in the api logs.
Truncate to grid bounds instead of raising an error when converting lat/lon to grid points.

Improved our messages for when we get system errors from API calls.
Put a time limit on the JWT cache used in gridded API calls so after 5 minutes it will re-get the JWT token from the server instead of using the cached version. This all allow us to remove someones registered PIN and after 5 minutes they will starting getting errors even if they are running in a process with a cached JWT token.