### PR TITLE
allow structure_type as a filter parameters for backward compatibility

### DIFF
--- a/docs/dataset_text.yaml
+++ b/docs/dataset_text.yaml
@@ -329,7 +329,7 @@ datasets:
 
 
       You can download the full WTD file using `hf_hydrodata.get_raw_file() <https://hf-hydrodata.readthedocs.io/en/latest/hf_hydrodata.gridded.html#hf_hydrodata.gridded.get_raw_file>`_. 
-      Or download subsets of the file using `hf_hydrodata.get_gridded_data() <https://hf-hydrodata.readthedocs.io/en/latest/hf_hydrodata.gridded.html#hf_hydrodata.gridded.get_gridded_data>_`.
+      Or download subsets of the file using `hf_hydrodata.get_gridded_data() <https://hf-hydrodata.readthedocs.io/en/latest/hf_hydrodata.gridded.html#hf_hydrodata.gridded.get_gridded_data>`_.
       See the linked Python API Reference for example syntax.
 
     processing_notes: >

--- a/docs/dataset_text.yaml
+++ b/docs/dataset_text.yaml
@@ -328,8 +328,9 @@ datasets:
       and NSE = 0.62.
 
 
-      You can download the full WTD file using get_raw_file(). Or download subsets of the file using get_gridded_data().
-      See Python API Reference for get_raw_file() in hf_hydrodata.gridded module.
+      You can download the full WTD file using `hf_hydrodata.get_raw_file() <https://hf-hydrodata.readthedocs.io/en/latest/hf_hydrodata.gridded.html#hf_hydrodata.gridded.get_raw_file>`_. 
+      Or download subsets of the file using `hf_hydrodata.get_gridded_data() <https://hf-hydrodata.readthedocs.io/en/latest/hf_hydrodata.gridded.html#hf_hydrodata.gridded.get_gridded_data>_`.
+      See the linked Python API Reference for example syntax.
 
     processing_notes: >
       Long-term mean water table depth estimates were obtained using the median of tree outputs from the trained random 
@@ -339,5 +340,5 @@ datasets:
   "ma_2025_cog":
     summary: >
       A copy of the ma_2025 30m dataset stored as a COG (Cloud Optimized Geotiff).
-      You can download the full WTD COG file using get_raw_file().
-      See Python API Reference for get_raw_file() in hf_hydrodata.gridded module.
+      You can download the full WTD COG file using `hf_hydrodata.get_raw_file() <https://hf-hydrodata.readthedocs.io/en/latest/hf_hydrodata.gridded.html#hf_hydrodata.gridded.get_raw_file>`_.
+      See the linked Python API Reference for example syntax.

--- a/docs/dataset_text.yaml
+++ b/docs/dataset_text.yaml
@@ -327,7 +327,17 @@ datasets:
       topographic features (elevation, slope, distances to streams), achieving test performance of r = 0.79, RMSE = 14.94 m, 
       and NSE = 0.62.
 
+
+      You can download the full WTD file using get_raw_file(). Or download subsets of the file using get_gridded_data().
+      See Python API Reference for get_raw_file() in hf_hydrodata.gridded module.
+
     processing_notes: >
       Long-term mean water table depth estimates were obtained using the median of tree outputs from the trained random 
       forest model. The uncertainty was assessed based on the interquantile range of the tree outputs from the random 
       forest model.
+
+  "ma_2025_cog":
+    summary: >
+      A copy of the ma_2025 30m dataset stored as a COG (Cloud Optimized Geotiff).
+      You can download the full WTD COG file using get_raw_file().
+      See Python API Reference for get_raw_file() in hf_hydrodata.gridded module.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -15,7 +15,7 @@ of the problem.
 
 How can I download a copy of the ma_2025 30m Water Table Depth Product?
 ----------------------------------------------------------------------------
-You can download a subset of the 30m water table depth file using the `hf_hydrodata.get_gridded_data() <https://hf-hydrodata.readthedocs.io/en/latest/hf_hydrodata.gridded.html#hf_hydrodata.gridded.get_gridded_data>_` function using
+You can download a subset of the 30m water table depth file using the `hf_hydrodata.get_gridded_data() <https://hf-hydrodata.readthedocs.io/en/latest/hf_hydrodata.gridded.html#hf_hydrodata.gridded.get_gridded_data>`_ function using
 a grid_bounds or latlon_bounds filter limited to about 2GB download.
 
 You can download the full version of the 30m water table depth using the `hf_hydrodata.get_raw_file() <https://hf-hydrodata.readthedocs.io/en/latest/hf_hydrodata.gridded.html#hf_hydrodata.gridded.get_raw_file>`_ function. 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -15,12 +15,12 @@ of the problem.
 
 How can I download a copy of the ma_2025 30m Water Table Depth Product?
 ----------------------------------------------------------------------------
-You can download a subset of the 30m water table depth file using the hf_hydrodata.get_gridded_data() function using
+You can download a subset of the 30m water table depth file using the `hf_hydrodata.get_gridded_data() <https://hf-hydrodata.readthedocs.io/en/latest/hf_hydrodata.gridded.html#hf_hydrodata.gridded.get_gridded_data>_` function using
 a grid_bounds or latlon_bounds filter limited to about 2GB download.
 
-You can download the full version of the 30m water table depth using the hf_hydrodata.get_raw_file() function. 
+You can download the full version of the 30m water table depth using the `hf_hydrodata.get_raw_file() <https://hf-hydrodata.readthedocs.io/en/latest/hf_hydrodata.gridded.html#hf_hydrodata.gridded.get_raw_file>`_ function. 
 
-See the Python API Reference documentation of the get_raw_file() function 
-in the hf_hydrodata.gridded module for examples. You can get this as either as a tiff file or a cog file.
+See the Python API Reference documentation of the `hf_hydrodata.get_raw_file() <https://hf-hydrodata.readthedocs.io/en/latest/hf_hydrodata.gridded.html#hf_hydrodata.gridded.get_raw_file>`_ function for examples.
+You can get this as either as a tiff file or a cog file.
 You can also get the ma_2025 wtd_uncertainty variable and the belitz_2019 dataset variables the same way.
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -12,3 +12,15 @@ from 6 AM to 2 PM Eastern Time. During this time, users may (but not always) exp
 If you encounter this error, we suggest trying again after the maintenance window has ended. 
 If you continue to experience issues after the maintenance period, please open a GitHub Issue with a detailed description 
 of the problem.
+
+How can I download a copy of the ma_2025 30m Water Table Depth Product?
+----------------------------------------------------------------------------
+You can download a subset of the 30m water table depth file using the hf_hydrodata.get_gridded_data() function using
+a grid_bounds or latlon_bounds filter limited to about 2GB download.
+
+You can download the full version of the 30m water table depth using the hf_hydrodata.get_raw_file() function. 
+
+See the Python API Reference documentation of the get_raw_file() function 
+in the hf_hydrodata.gridded module for examples. You can get this as either as a tiff file or a cog file.
+You can also get the ma_2025 wtd_uncertainty variable and the belitz_2019 dataset variables the same way.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.4.5"
+version = "1.4.6"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -1145,33 +1145,53 @@ def _write_file_from_api(filepath: str, options: dict):
                 if response.status_code == 502:
                     message = "Server '%s' is not responding. Try again later."
                     _send_download_complete_reply(
-                        response, headers, download_start, message=message, reply_route="data-file"
+                        response,
+                        headers,
+                        download_start,
+                        message=message,
+                        reply_route="data-file",
                     )
                     raise ValueError(message) from None
                 message = (
                     f"The {HYDRODATA_URL} returned error code {response.status_code}."
                 )
                 _send_download_complete_reply(
-                    response, headers, download_start, message=message, reply_route="data-file"
+                    response,
+                    headers,
+                    download_start,
+                    message=message,
+                    reply_route="data-file",
                 )
                 raise ValueError(message) from None
 
         except requests.exceptions.Timeout:
             message = "Timeout error from server. Try again later or modify the query."
             _send_download_complete_reply(
-                response, headers, download_start, message=message, reply_route="data-file"
+                response,
+                headers,
+                download_start,
+                message=message,
+                reply_route="data-file",
             )
             raise ValueError(message) from None
         except requests.exceptions.ChunkedEncodingError:
             message = f"The {datafile_url} has timed out. Try again later or change your query."
             _send_download_complete_reply(
-                response, headers, download_start, message=message, reply_route="data-file"
+                response,
+                headers,
+                download_start,
+                message=message,
+                reply_route="data-file",
             )
             raise ValueError(message) from None
         except Exception as e:
             message = str(e)
             _send_download_complete_reply(
-                response, headers, download_start, message=message, reply_route="data-file"
+                response,
+                headers,
+                download_start,
+                message=message,
+                reply_route="data-file",
             )
             raise ValueError(message) from None
 
@@ -1217,7 +1237,9 @@ def _write_file_from_api(filepath: str, options: dict):
         download_start = (
             updated_download_start if updated_download_start else download_start
         )
-        _send_download_complete_reply(response, headers, download_start, reply_route="data-file")
+        _send_download_complete_reply(
+            response, headers, download_start, reply_route="data-file"
+        )
 
         if offset_end:
             offset = offset_end + 1
@@ -2623,14 +2645,18 @@ def _slice_da_bounds(da: xr.DataArray, grid: str, options: dict) -> xr.DataArray
     if grid_row is None:
         raise ValueError(f"No such grid {grid} available.")
     grid_shape = grid_row["shape"]
-    if (
-        len(grid_shape) >= 3
-        and (grid_bounds[0] < 0 or grid_bounds[0] > grid_shape[2])
-        or (grid_bounds[1] < 0 or grid_bounds[3] > grid_shape[1])
-    ):
-        raise ValueError(
-            f"grid_bounds {grid_bounds[0]},{grid_bounds[1]} is outside the grid shape {grid_shape[2]}, {grid_shape[1]}."
-        )
+    if len(grid_shape) < 2:
+        raise ValueError(f"Grid shape not available for grid '{grid}'/")
+    shape_bounds = (
+        [grid_shape[2], grid_shape[1]]
+        if len(grid_shape) >= 3
+        else [grid_shape[1], grid_shape[0]] if len(grid_shape) == 2 else None
+    )
+    for index, bound in enumerate(grid_bounds):
+        if bound < 0 or bound > shape_bounds[index % 2]:
+            raise ValueError(
+                f"grid_bounds {grid_bounds} is outside the grid shape {shape_bounds[0]}, {shape_bounds[1]}."
+            )
 
     if grid_bounds:
         if len(da.shape) == 3:
@@ -2670,7 +2696,13 @@ def _get_pfb_boundary_constraints(grid: str, options: dict) -> dict:
     if grid_row is None:
         raise ValueError(f"No such grid {grid} available.")
     grid_shape = grid_row["shape"]
-
+    if len(grid_shape) < 2:
+        raise ValueError(f"Grid shape not available for grid '{grid}'/")
+    shape_bounds = (
+        [grid_shape[2], grid_shape[1]]
+        if len(grid_shape) >= 3
+        else [grid_shape[1], grid_shape[0]] if len(grid_shape) == 2 else None
+    )
     result = None
     if x is not None:
         if y is None:
@@ -2678,13 +2710,9 @@ def _get_pfb_boundary_constraints(grid: str, options: dict) -> dict:
         z = int(z) if z is not None else 0
         x = float(x)
         y = float(y)
-        if (
-            len(grid_shape) >= 3
-            and (x < 0 or x > grid_shape[2])
-            or (y < 0 or y > grid_shape[1])
-        ):
+        if x < 0 or x > shape_bounds[0] or y < 0 or y > shape_bounds[1]:
             raise ValueError(
-                f"Point {x},{y} is outside the grid shape {grid_shape[2]}, {grid_shape[1]}."
+                f"Point {x},{y} is outside the grid shape {shape_bounds[0]}, {shape_bounds[0]}."
             )
         result = {
             "x": {"start": int(x), "stop": int(x)},
@@ -2692,14 +2720,11 @@ def _get_pfb_boundary_constraints(grid: str, options: dict) -> dict:
             "z": {"start": z, "stop": z},
         }
     elif grid_bounds:
-        if (
-            len(grid_shape) >= 3
-            and (grid_bounds[0] < 0 or grid_bounds[0] > grid_shape[2])
-            or (grid_bounds[1] < 0 or grid_bounds[3] > grid_shape[1])
-        ):
-            raise ValueError(
-                f"grid_bounds {grid_bounds[0]},{grid_bounds[1]} is outside the grid shape {grid_shape[2]}, {grid_shape[1]}."
-            )
+        for index, bound in enumerate(grid_bounds):
+            if bound < 0 or bound > shape_bounds[index % 2]:
+                raise ValueError(
+                    f"grid_bounds {grid_bounds} is outside the grid shape {shape_bounds[0]}, {shape_bounds[1]}."
+                )
         result = {
             "x": {"start": int(grid_bounds[0]), "stop": int(grid_bounds[2])},
             "y": {"start": int(grid_bounds[1]), "stop": int(grid_bounds[3])},
@@ -3327,8 +3352,10 @@ def _get_grid_bounds(grid: str, options: dict, rio_ds=None) -> List[float]:
         nx = grid_bounds[2] - grid_bounds[0]
         ny = grid_bounds[3] - grid_bounds[1]
         if nx < 0 or ny < 0:
-            raise ValueError("The grid bounds specifies a negative x or y dimension. Should be [xmin,ymin,xmax,ymax].")
-        
+            raise ValueError(
+                "The grid bounds specifies a negative x or y dimension. Should be [xmin,ymin,xmax,ymax]."
+            )
+
     # Return the grid_bounds assuming 0,0 is south west
     return grid_bounds
 

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -1252,26 +1252,39 @@ def _write_file_from_api(filepath: str, options: dict):
 
 @_maintenance_guard
 def get_raw_file(filepath, *args, **kwargs):
-    """Get the hydroframe file that is selected by the options to the given filepath.
+    """
+    Get the hydroframe file that is selected by the options.
+
+    This can be used to get smaller files such as huc_mapping file with the HUC ids for points in conus2.
+    This can also be used to get large files (24 GB) such as the 30m water table depth file or wtd_uncertainty file.
+
+    Larger files are streamed to the filepath. If the connection is dropped while downloading you can restart
+    the function writing to the same file and it will continue where it left off if the file exists already.
 
     Args:
-        filepath:          Either a ModelTableRow or the ID number of a data_catalog_entry. If None use the entry found by the filters.
-        options:           Optional positional parameter that must be a dict with data filter options.
+        filepath:          A path name to the file to store the downloaded data.
+        options:           Any hf_hydrodata filter options. This must identify a single file. You may need to specify a date_start option if the catalog entry has a temporal resolution and the data is stored in multiple files.
     Returns:
         None
     Raises:
         ValueError:        If there are multiple paths selected from hydroframe.
 
-    Example:
+    Examples:
 
     .. code-block:: python
 
         import hf_hydrodata as hf
-
         options = {
             "dataset": "huc_mapping", "grid": "conus2", "level": "4"}
         }
         hf.get_raw_file("huc4.tiff", options)
+
+        options = {"dataset": "ma_2025", "variable": "water_table_depth", "grid": "conus2_wtd.30"}
+        hf.get_raw_file("wtd.tiff", options)
+
+        options = {"dataset": "ma_2025_cog", "variable": "water_table_depth"}
+        hf.get_raw_file("wtd.cog.tiff", options)
+
     """
     if len(args) > 0 and isinstance(args[0], dict):
         # The filter options are being passed using a dict

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -1511,6 +1511,8 @@ def _check_for_unknown_options(options: dict):
         "threads",
         "offset",
         "from",
+        "structure_type",
+        "return_coordinates",
     ]
     unknown_keys = []
     for key in options:

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -1119,7 +1119,7 @@ def _write_file_from_api(filepath: str, options: dict):
             # Loop through request retry responses if message queue detects low server disk space
             for retry_count in range(0, 70):
                 response = requests.get(
-                    datafile_url, headers=headers, stream=True, timeout=(10, 60)
+                    datafile_url, headers=headers, stream=True, timeout=(80, 180)
                 )
                 if retry_count == 0:
                     download_start = response.headers.get("download-start")
@@ -1184,6 +1184,9 @@ def _write_file_from_api(filepath: str, options: dict):
                 reply_route="data-file",
             )
             raise ValueError(message) from None
+        except ValueError as ve:
+            # This error has already been logged back to server
+            raise ve
         except Exception as e:
             message = str(e)
             _send_download_complete_reply(
@@ -1910,7 +1913,7 @@ def _get_gridded_data_from_api(options):
         gridded_data_url = f"{HYDRODATA_URL}/api/gridded-data?{q_params}"
         try:
             headers = _get_api_headers()
-            response = requests.get(gridded_data_url, headers=headers, timeout=(10, 60))
+            response = requests.get(gridded_data_url, headers=headers, timeout=(80, 180))
             response_headers = response.headers
             download_start = response_headers.get("download-start")
             for retry_count in range(0, 80):
@@ -1920,7 +1923,7 @@ def _get_gridded_data_from_api(options):
                     retry_location = response_headers.get("Location")
                     retry_url = f"{HYDRODATA_URL}/api{retry_location}?download_start={download_start}"
                     response = requests.get(
-                        retry_url, headers=headers, timeout=(10, 60)
+                        retry_url, headers=headers, timeout=(80, 180)
                     )
                     sleep_duration = (
                         1 if retry_count < 10 else 2 if retry_count < 30 else 4
@@ -1959,6 +1962,9 @@ def _get_gridded_data_from_api(options):
                 response, headers, download_start, message=message
             )
             raise ValueError(message) from te
+        except ValueError as ve:
+            # This error was already logged back at server
+            raise ve
         except Exception as e:
             message = str(e)
             _send_download_complete_reply(

--- a/src/hf_hydrodata/point.py
+++ b/src/hf_hydrodata/point.py
@@ -1,6 +1,6 @@
 """Module to retrieve point observations."""
 
-# pylint: disable=C0301,W0707,W0719,C0121,C0302,C0209,C0325,W0702,R0912,R0914
+# pylint: disable=C0301,W0707,W0719,C0121,C0302,C0209,C0325,W0702,R0912,R0914,R0915,W1514,C0206
 import datetime
 from typing import Tuple
 import io
@@ -31,6 +31,7 @@ HYDRODATA = "/hydrodata"
 DB_PATH = f"{HYDRODATA}/national_obs/point_obs.sqlite"
 HYDRODATA_URL = os.getenv("HYDRODATA_URL", "https://hydrogen.princeton.edu")
 NETWORK_LISTS_PATH = f"{HYDRODATA}/national_obs/tools/network_lists"
+MAX_NUMBER_OF_SITES = 250000
 
 # Use this to check that user-supplied parameters are being used
 SUPPORTED_FILTERS = [
@@ -259,6 +260,7 @@ def get_point_data(*args, **kwargs):
 
     # Get data
     site_list = list(sites_df["site_id"])
+    _check_max_sites(site_list)
 
     if (var_id in (1, 2, 3, 4)) | (var_id in range(6, 25)):
         data_df = _get_data_nc(
@@ -955,7 +957,7 @@ def _get_siteid_data_from_api(options):
     download_start = None
     try:
         headers = _validate_user()
-        response = requests.get(point_data_url, headers=headers, timeout=(10, 180))
+        response = requests.get(point_data_url, headers=headers, timeout=(60, 180))
         response_headers = response.headers
         download_start = response_headers.get("download-start")
         for retry_count in range(0, 60):
@@ -964,7 +966,7 @@ def _get_siteid_data_from_api(options):
                 # Retry
                 retry_location = response_headers.get("Location")
                 retry_url = f"{HYDRODATA_URL}/api{retry_location}?download_start={download_start}"
-                response = requests.get(retry_url, headers=headers, timeout=(10, 180))
+                response = requests.get(retry_url, headers=headers, timeout=(60, 180))
                 sleep_duration = 1 if retry_count < 10 else 2 if retry_count < 30 else 4
                 time.sleep(sleep_duration)
 
@@ -978,20 +980,32 @@ def _get_siteid_data_from_api(options):
             # send a response for any other non-200 error to log the error
             message = f"{response.content}."
             _send_download_complete_reply(
-                response, headers, "site-variables-dataframe", download_start, message=message
+                response,
+                headers,
+                "site-variables-dataframe",
+                download_start,
+                message=message,
             )
             raise ValueError(message)
 
-    except requests.exceptions.Timeout as te:
-        message = f"The remote get_site_variables has timed out."
+    except requests.exceptions.Timeout:
+        message = "The remote get_site_variables has timed out."
         _send_download_complete_reply(
-            response, headers, "site-variables-dataframe", download_start, message=message
+            response,
+            headers,
+            "site-variables-dataframe",
+            download_start,
+            message=message,
         )
         raise ValueError(message)
     except Exception as e:
         message = f"The remote get_site_variables has failed with: {str(e)}"
         _send_download_complete_reply(
-            response, headers, "site-variables-dataframe", download_start, message=message
+            response,
+            headers,
+            "site-variables-dataframe",
+            download_start,
+            message=message,
         )
         raise ValueError(message)
 
@@ -1019,7 +1033,7 @@ def _get_data_from_api(data_type, options):
     download_start = None
     try:
         headers = _validate_user()
-        response = requests.get(point_data_url, headers=headers, timeout=(10, 180))
+        response = requests.get(point_data_url, headers=headers, timeout=(60, 180))
         response_headers = response.headers
         download_start = response_headers.get("download-start")
         for retry_count in range(0, 60):
@@ -1028,7 +1042,7 @@ def _get_data_from_api(data_type, options):
                 # Retry
                 retry_location = response_headers.get("Location")
                 retry_url = f"{HYDRODATA_URL}/api{retry_location}?download_start={download_start}"
-                response = requests.get(retry_url, headers=headers, timeout=(10, 180))
+                response = requests.get(retry_url, headers=headers, timeout=(60, 180))
                 sleep_duration = 1 if retry_count < 10 else 2 if retry_count < 30 else 4
                 time.sleep(sleep_duration)
             elif response.status_code != 200:
@@ -1040,21 +1054,29 @@ def _get_data_from_api(data_type, options):
                 if response.status_code == 502:
                     message = "Server not available error. Try again later."
                     _send_download_complete_reply(
-                        response, headers, "point-data-dataframe", download_start, message=message
+                        response,
+                        headers,
+                        "point-data-dataframe",
+                        download_start,
+                        message=message,
                     )
                     raise ValueError(message)
                 message = f"Server error {response.status_code}. Try again later."
                 _send_download_complete_reply(
-                    response, headers, "point-data-dataframe", download_start, message=message
+                    response,
+                    headers,
+                    "point-data-dataframe",
+                    download_start,
+                    message=message,
                 )
                 raise ValueError(message)
-    except requests.exceptions.ChunkedEncodingError as ce:
+    except requests.exceptions.ChunkedEncodingError:
         message = "Chunking error from server. Try again later or modify query."
         _send_download_complete_reply(
             response, headers, "point-data-dataframe", download_start, message=message
         )
         raise ValueError(message)
-    except requests.exceptions.Timeout as te:
+    except requests.exceptions.Timeout:
         message = "Timeout error from server. Try again later or modify query."
         _send_download_complete_reply(
             response, headers, "point-data-dataframe", download_start, message=message
@@ -1249,11 +1271,13 @@ def _validate_user():
     try:
         email, pin = _get_registered_api_pin()
         url_security = f"{HYDRODATA_URL}/api/api_pins?pin={pin}&email={email}"
-        response = requests.get(url_security, headers=None, timeout=(10, 60))
+        response = requests.get(url_security, headers=None, timeout=(60, 60))
         if response.status_code == 502:
             raise ValueError("Server is unavailable. Try again later.")
         if not response.status_code == 200:
-            raise ValueError(f"Unable to authenticate with your email/pin with '{HYDRODATA_URL}' server.")
+            raise ValueError(
+                f"Unable to authenticate with your email/pin with '{HYDRODATA_URL}' server."
+            )
         json_string = response.content.decode("utf-8")
         jwt_json = json.loads(json_string)
         expires_string = jwt_json.get("expires")
@@ -1273,7 +1297,10 @@ def _validate_user():
     except ValueError as ve:
         raise ve
     except:
-        raise ValueError(f"Unable to authenticate with your email/pin with '{HYDRODATA_URL}' server.")
+        raise ValueError(
+            f"Unable to authenticate with your email/pin with '{HYDRODATA_URL}' server."
+        )
+
 
 def _get_variables(conn):
     """
@@ -1670,6 +1697,7 @@ def _get_sites(
                         """
         grid_bounds_df = pd.read_sql_query(grid_bounds_query, conn)
         grid_bounds_sites = list(grid_bounds_df["site_id"])
+        _check_max_sites(grid_bounds_sites)
 
         if len(grid_bounds_sites) > 0:
             grid_bounds_query = " AND s.site_id IN (%s)" % ",".join(
@@ -1767,8 +1795,7 @@ def _get_sites(
         clipped_df = _filter_on_polygon(df, options["polygon"], options["polygon_crs"])
         return clipped_df
 
-    else:
-        return df
+    return df
 
 
 def _get_bbox_from_shape(polygon, polygon_crs):
@@ -2161,8 +2188,7 @@ def _get_data_nc(
     data_df = _convert_to_pandas(ds)
     if "min_num_obs" in options and options["min_num_obs"] is not None:
         return _filter_min_num_obs(data_df, options["min_num_obs"])
-    else:
-        return data_df
+    return data_df
 
 
 def _get_data_sql(conn, site_list, var_id, *args, **kwargs):
@@ -2415,7 +2441,7 @@ def _send_download_complete_reply(
             "download_start": download_start,
             "error_message": message,
             "job_queue_duration": job_queue_duration,
-            "job_query_parameters": job_query_parameters
+            "job_query_parameters": job_query_parameters,
         }
     else:
         query_parameters = {"error_message": message}
@@ -2433,3 +2459,12 @@ def _send_download_complete_reply(
             requests.delete(url, headers=request_headers, timeout=60)
         except:
             pass
+
+
+def _check_max_sites(site_list):
+    """Check to see if the number of sites in the site list exeeded maximum."""
+
+    if len(site_list) > MAX_NUMBER_OF_SITES:
+        raise ValueError(
+            f'Too many sites > {MAX_NUMBER_OF_SITES} selected ({len(site_list)})for one request. Try filtering by latitude_range, longitude_range, grid_bounds or state (for example "state": "NJ")'
+        )

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -2519,17 +2519,17 @@ def test_monthly_across_wy():
 def test_belitz_dataset():
     """Test that we can read the belitz_2019 dataset with bounds filters."""
 
-    filter = {
+    options = {
         "dataset": "belitz_2019",
         "variable": "distance_stream_horizontal",
         "grid_bounds": [80000, 80000, 80005, 80010],
     }
-    data = hf.get_gridded_data(filter)
+    data = hf.get_gridded_data(options)
     assert data.shape == (10, 5)
     assert data[2, 2] == pytest.approx(240.0)
     assert data[4, 3] == pytest.approx(300.0)
 
-    filter = {
+    options = {
         "dataset": "belitz_2019",
         "variable": "distance_stream_horizontal",
         "latlon_bounds": [
@@ -2539,10 +2539,11 @@ def test_belitz_dataset():
             -102.68208333331141,
         ],
     }
-    data = hf.get_gridded_data(filter)
+    data = hf.get_gridded_data(options)
     assert data.shape == (10, 5)
     assert data[2, 2] == pytest.approx(240.0)
     assert data[4, 3] == pytest.approx(300.0)
+
 
 def test_negative_grid_bounds():
     """Test error message for negative grid bounds."""
@@ -2560,3 +2561,22 @@ def test_negative_grid_bounds():
         grid_bounds = [1000, 1000, 1010, 900]
         bounds = hf.gridded._get_grid_bounds("conus2", {"grid_bounds": grid_bounds})
     assert "specifies a negative" in str(info.value)
+
+
+def test_get_bounds_limits():
+    """Test error check when grid_bounds limits it outside shape bounds."""
+    grid_bounds = [1533, 1545, 3701, 3702]
+    options = {
+        "dataset": "conus2_domain",
+        "variable": "elevation",
+        "temporal_resolution": "static",
+        "aggregation": "-",
+        "file_type": "pfb",
+        "structure_type": "gridded",
+        "time_values": "null",
+        "return_coordinates": "false",
+        "grid_bounds": grid_bounds,
+    }
+    with pytest.raises(ValueError) as info:
+        hf.get_gridded_data(options)
+    assert "is outside the grid" in str(info.value)

--- a/tests/hf_hydrodata/test_point.py
+++ b/tests/hf_hydrodata/test_point.py
@@ -1923,6 +1923,33 @@ def test_maintenance_error_point_pass(monkeypatch):
     )
     assert len(df) == 5
 
+def test_all_sites_point_data():
+    """Test for daily streamflow data for all sites. This should raise an error"""
+    with pytest.raises(ValueError) as info:
+        point.get_point_data(
+            dataset="fan_2013",
+            variable="water_table_depth",
+            temporal_resolution="long_term",
+            aggregation="mean",
+            date_start="2002-01-01",
+            date_end="2002-01-05",
+        )
+
+def test_large_number_of_sites():
+    """Test for large number of sites."""
+    bounds = [0, 0, 2300, 2000]
+    grid = "conus2"
+    df = point.get_point_data(
+        dataset="fan_2013",
+        variable="water_table_depth",
+        temporal_resolution="long_term",
+        aggregation="mean",
+        date_start="2002-01-01",
+        date_end="2002-01-05",
+        grid=grid,
+        grid_bounds=bounds
+    )
+    assert(len(df)) > 100000
 
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
Add structure type as an allowed parameter for backward compatibility.
Add error check if grid_bounds is out of range of the shape of the grid.
Add read-the-docs help for reading large 30m dataset files using get_raw_file().
Change timeout values again for requests.get().
Raise an error if the number of sites in a get_point_data request is more then 250000.