### PR TITLE
Add Zenodo instructions in the-the-docs FAQ

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -24,3 +24,5 @@ See the Python API Reference documentation of the `hf_hydrodata.get_raw_file() <
 You can get this as either as a tiff file or a cog file.
 You can also get the ma_2025 wtd_uncertainty variable and the belitz_2019 dataset variables the same way.
 
+We also have the full ma_2025 water table depth dataset available as a tiff file
+on `Zenodo <https://zenodo.org/records/18504963>`_ as a direct download.

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -1261,7 +1261,7 @@ def get_raw_file(filepath, *args, **kwargs):
     This can be used to get smaller files such as huc_mapping file with the HUC ids for points in conus2.
     This can also be used to get large files (24 GB) such as the 30m water table depth file or wtd_uncertainty file.
 
-    Note - the 30m resolution full datasets are large - 25GB for the cog and 35 GB for the tiff.
+    Note - the 30m resolution full datasets are large - 25 GB for the cog and 35 GB for the tiff.
     It can take about 20-40 minutes to download these large files. If your connection drops you can restart
     the function writing to the same file and it will continue where it left off. If multiple people
     are trying to download a large file at the same time your request may be queued and take longer per

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -1261,8 +1261,11 @@ def get_raw_file(filepath, *args, **kwargs):
     This can be used to get smaller files such as huc_mapping file with the HUC ids for points in conus2.
     This can also be used to get large files (24 GB) such as the 30m water table depth file or wtd_uncertainty file.
 
-    Larger files are streamed to the filepath. If the connection is dropped while downloading you can restart
-    the function writing to the same file and it will continue where it left off if the file exists already.
+    Note - the 30m resolution full datasets are large - 25GB for the cog and 35 GB for the tiff.
+    It can take about 20-40 minutes to download these large files. If your connection drops you can restart
+    the function writing to the same file and it will continue where it left off. If multiple people
+    are trying to download a large file at the same time your request may be queued and take longer per
+    chunking request during your download.
 
     Args:
         filepath:          A path name to the file to store the downloaded data.


### PR DESCRIPTION
Update the Read-the-Docs instructions with the Zenodo link.
And update the DocString in get_raw_file() to say how long a download takes for the large files.
