### PR TITLE
update docs

### DIFF
--- a/docs/dataset_text.yaml
+++ b/docs/dataset_text.yaml
@@ -328,9 +328,12 @@ datasets:
       and NSE = 0.62.
 
 
-      You can download the full WTD file using `hf_hydrodata.get_raw_file() <https://hf-hydrodata.readthedocs.io/en/latest/hf_hydrodata.gridded.html#hf_hydrodata.gridded.get_raw_file>`_. 
-      Or download subsets of the file using `hf_hydrodata.get_gridded_data() <https://hf-hydrodata.readthedocs.io/en/latest/hf_hydrodata.gridded.html#hf_hydrodata.gridded.get_gridded_data>`_.
-      See the linked Python API Reference for example syntax.
+      You can download the full WTD tiff file using `Zenodo <https://zenodo.org/records/18504963>`_ or 
+      using `hf_hydrodata.get_raw_file() <https://hf-hydrodata.readthedocs.io/en/latest/hf_hydrodata.gridded.html#hf_hydrodata.gridded.get_raw_file>`_. 
+      You can get subsets of the dataset as a numpy array using `hf_hydrodata.get_gridded_data() <https://hf-hydrodata.readthedocs.io/en/latest/hf_hydrodata.gridded.html#hf_hydrodata.gridded.get_gridded_data>`_,
+      or download a file containing a subset of the data as a file with projection information as a TIFF or NetCDF file using
+      `hf_hydrodata.get_gridded_file() <https://hf-hydrodata.readthedocs.io/en/latest/hf_hydrodata.gridded.html#hf_hydrodata.gridded.get_gridded_file>`_.
+      You can select a subset using the filter options: grid_bounds, latlon_bounds or huc_id.
 
     processing_notes: >
       Long-term mean water table depth estimates were obtained using the median of tree outputs from the trained random 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -45,6 +45,12 @@ Additionally, the :ref:`api` can be used to see the full list of available featu
 
 Please see :ref:`api_pin` to make sure you have properly signed up and registered your API PIN.
 
+Browsing Available Datasets
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+You can browse the available datasets by using the `Data Catalog Browser <https://hydroframe.org/datacatalog-browser>`_ 
+from the `hydroframe.org <https://hydroframe.org>`_ website. 
+You can also use this browser to download sample data with projection information of entries from the data catalog.
+
 Accessing Gridded Data
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This PR adds some text to the documentation. There is a new section in the QuickStart Guide that introduces the Data Catalog browser. There is also additional text explaining various ways to access the high-resolution water table depth dataset. Screenshots below are from a local rendering of the docs.

<img width="748" height="390" alt="Screenshot 2026-05-21 at 9 45 50 AM" src="https://github.com/user-attachments/assets/62c9667a-3a8a-4d53-bc26-d05b22f1d94f" />

<img width="759" height="431" alt="Screenshot 2026-05-21 at 9 46 13 AM" src="https://github.com/user-attachments/assets/95efe7c6-0ee5-4848-910e-101d2fb12043" />
