### PR TITLE
remove cw3e version 0.9

### DIFF
--- a/docs/dataset_text.yaml
+++ b/docs/dataset_text.yaml
@@ -97,7 +97,7 @@ datasets:
         - Upper Colorado River Basin (HUC 14): temperature lapse rate correction at 2.5 K/km 
 
 
-      **Version 0.9**: Initial version of CW3E dataset.
+      **Version 0.9**: Initial version of CW3E dataset (deprecated).
 
   "huc_mapping":
     summary: >

--- a/tests/hf_hydrodata/test_data_catalog.py
+++ b/tests/hf_hydrodata/test_data_catalog.py
@@ -114,11 +114,6 @@ def test_dataset_version():
     """Test reading catalog entries with dataset_versions"""
 
     row = hf.get_catalog_entry(
-        dataset="CW3E", period="hourly", variable="precipitation", dataset_version="0.9"
-    )
-    assert row["id"] == "167"
-
-    row = hf.get_catalog_entry(
         dataset="CW3E",
         period="hourly",
         variable="precipitation",
@@ -148,17 +143,6 @@ def test_catalog_preference_dataset_version():
     entry = hf.get_catalog_entry(option)
     assert entry["aggregation"] == "-"
     assert entry["dataset_version"] == "1.0"
-
-    option = {
-        "dataset": "CW3E",
-        "variable": "air_temp",
-        "temporal_resolution": "hourly",
-        "dataset_version": "0.9",
-        "start_time": "2001-01-01",
-    }
-    entry = hf.get_catalog_entry(option)
-    assert entry["aggregation"] == "-"
-    assert entry["dataset_version"] == "0.9"
 
 
 def test_catalog_preference_file_type():

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -242,7 +242,8 @@ def test_files_exist():
                     "site_id": site_id,
                 }
             )
-            if data_catalog_entry_id not in [
+            # Ignore HydroGEN entries and files known to not exist
+            if (data_catalog_entry_id not in [
                 "253",
                 "254",
                 "10003",
@@ -254,8 +255,7 @@ def test_files_exist():
                 "10009",
                 "10010",
                 "10011",
-            ]:
-                # Ignore HydroGEN entries and files known to not exist
+            ]) and ("CW3E_v0.9" not in path_example):
                 dataset = entry["dataset"]
                 if not os.path.exists(path_example):
                     print(path_example, "does not exist")

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -1818,11 +1818,6 @@ def test_cw3e_version():
         "grid_bounds": [500, 2500, 501, 2501],
     }
 
-    options_version09 = options.copy()
-    options_version09["dataset_version"] = "0.9"
-    cw3e_version09 = hf.get_gridded_data(options_version09)
-    assert cw3e_version09[0, 0, 0] - 284.66085 <= 0.00001
-
     options_version1 = options.copy()
     options_version1["dataset_version"] = "1.0"
     cw3e_version1 = hf.get_gridded_data(options_version1)


### PR DESCRIPTION
Deprecate CW3E version 0.9 (known to have temporal mismatch against PRISM) in efforts to clean up disk space. 