### PR TITLE
pin pandas upper version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.22.1
-pandas>=1.3.5
+pandas>=1.3.5, <3.0.4
 pandoc>=2.3
 pypandoc>=1.12
 pip>=22.0.3 


### PR DESCRIPTION
Pandas version release to 3.0.4 yesterday caused segmentation faults in the running of hf-hydrodata unit tests. This update pins the version of pandas used to 3.0.3 at the upper level until those issues are resolved.