### PR TITLE
fix bug in reading hourly timesteps from netcdf files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.4.7"
+version = "1.4.8"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -3353,7 +3353,7 @@ def _create_da_indexer(options: dict, entry, data_ds, data_da, file_path: str) -
                     )
             elif period == "hourly":
                 time_index = int(
-                    (start_time_value - dimension_start_time).seconds / 3600
+                    (start_time_value - dimension_start_time).total_seconds() / 3600
                 )
             elif period == "monthly":
                 time_index = (
@@ -3385,7 +3385,7 @@ def _create_da_indexer(options: dict, entry, data_ds, data_da, file_path: str) -
                     end_time_index = (end_time_value - dimension_start_time).days
                 elif period == "hourly":
                     end_time_index = int(
-                        (end_time_value - dimension_start_time).seconds / 3600
+                        (end_time_value - dimension_start_time).total_seconds() / 3600
                     )
                 elif period == "monthly":
                     end_time_index = (

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -2693,3 +2693,29 @@ def test_gridded_file_pfb():
         hf.get_gridded_file(file_path, options)
         data = hf.gridded.read_fast_pfb(file_path)
         assert data.shape == (1, 144, 19, 48)
+
+
+def test_create_da_indexer_hourly_multiday_time_index():
+    """
+    Unit test that _create_da_indexer uses total_seconds() (not .seconds) when
+    computing the hourly time index from a netcdf file's time dimension.
+
+    timedelta.seconds wraps at 86400 (one day), so a start_time that is more
+    than 24 hours past the file's first timestep would produce a wrong index.
+    For example, 54 hours past the start: .seconds gives 6*3600 → index 6,
+    total_seconds() gives 54*3600 → index 54 (correct).
+    """
+    dimension_start = datetime.datetime(2005, 10, 1, 0, 0, 0)
+    times = [dimension_start + datetime.timedelta(hours=h) for h in range(100)]
+    data = np.zeros((100,))
+    data_da = xr.DataArray(data, dims=["time"], coords={"time": times}, name="var")
+    data_ds = data_da.to_dataset()
+
+    entry = {"temporal_resolution": "hourly", "grid": None}
+    # start_time is 54 hours (2 days + 6 hours) after the dimension start.
+    # .seconds would return 6*3600, giving index 6. total_seconds() gives 54.
+    options = {"start_time": "2005-10-03 06:00:00"}
+
+    da_indexers = gr._create_da_indexer(options, entry, data_ds, data_da, "synthetic.nc")
+
+    assert da_indexers["time"] == 54


### PR DESCRIPTION
This PR fixes a small bug in how the time indexing is determined when reading hourly timestep NetCDF files. There are currently no hourly timestep NetCDF files within the data catalog, but we will be adding some soon. There is a new test that captures the difference between using `.seconds` and `.total_seconds()` for this purpose.