### PR TITLE
remove check for existence of CW3E version 0.8 files

### DIFF
--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -255,7 +255,7 @@ def test_files_exist():
                 "10009",
                 "10010",
                 "10011",
-            ]) and ("CW3E_v0.9" not in path_example):
+            ]) and ("CW3E_Forcing_Update" not in path_example):
                 dataset = entry["dataset"]
                 if not os.path.exists(path_example):
                     print(path_example, "does not exist")


### PR DESCRIPTION
This PR removes the file existence check for the private version 0.8 of the CW3E dataset. We will be removing those files from the data catalog. In order to publish the schema with those records removed, we need to ensure all tests would pass first with those records removed.