### PR TITLE
fix error message and subgrid issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hf_hydrodata"
-version = "1.4.8"
+version = "1.4.9"
 description = "hydroframe tools and utilities"
 authors = ["William M. Hasling", "Laura Condon", "Reed Maxwell",  "George Artavanis", "Amy M. Johnson", "Amy C. Defnet"]
 license = "MIT"

--- a/src/hf_hydrodata/fast_pfb_reader.py
+++ b/src/hf_hydrodata/fast_pfb_reader.py
@@ -387,7 +387,7 @@ def find_subgrid(
     result_x = math.floor(x / sg_nx)
     remain_parts = result_x - remain_x
     full_parts = result_x - remain_parts
-    if result_x > remain_x:
+    if result_x >= remain_x:
         if x - full_parts * sg_nx - remain_parts * (sg_nx - 1) >= (sg_nx - 1):
             result_x = result_x + 1
 

--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -1642,6 +1642,12 @@ def get_gridded_data(*args, **kwargs) -> np.ndarray:
             raise ValueError(f"No entry found in data catalog for {args}.")
         _verify_time_in_range(entry, options)
 
+        temporal_resolution = entry.get("temporal_resolution")
+        if temporal_resolution not in ["static", "", "-"]:
+            start_date_value = _get_date_start(options)
+            if start_date_value is None:
+                raise ValueError(f"No date_start specified for download of dataset with temporal_resolution '{temporal_resolution}'")
+
         file_type = entry.get("file_type")
         structure_type = entry.get("structure_type")
         data = None

--- a/tests/hf_hydrodata/test_gridded.py
+++ b/tests/hf_hydrodata/test_gridded.py
@@ -2629,7 +2629,6 @@ def test_gridded_file_wtd():
     """Test downloading subset of 30m WTD usign get_gridded_file."""
 
     with tempfile.TemporaryDirectory() as tempdirname:
-        tempdirname = "."
         bounds = [3000, 3000, 3010, 3020]
         options = {
             "dataset": "ma_2025",
@@ -2719,3 +2718,34 @@ def test_create_da_indexer_hourly_multiday_time_index():
     da_indexers = gr._create_da_indexer(options, entry, data_ds, data_da, "synthetic.nc")
 
     assert da_indexers["time"] == 54
+
+def test_read_failure_subgrid():
+    """
+    Test that a read failure of a subgrid error that is fixed. This occurred with this
+    latlon value on the conus2_domain dataset and should be fixed and work now.
+    """
+
+    latlon = [34.47374326, -98.06526228]
+    options = {
+        "dataset": "conus2_domain",
+        "variable": "porosity",
+        "latlon_point" : latlon,
+    }
+    data = hf.get_gridded_data(options)
+    assert data.shape == (10, 1, 1)
+
+def test_temporal_resolution_no_date():
+    """
+    Test the error message that occurs when you read a dataset with
+    a temporal resolution, but do not pass a start date to the query.
+    """
+
+    latlon = [34.47374326, -98.06526228]
+    options = {
+        "dataset": "conus1_baseline_mod",
+        "variable": "saturation",
+        "latlon_point" : latlon,
+    }
+    with pytest.raises(ValueError) as err:
+        data = hf.get_gridded_data(options)
+    assert "No date_start specified for download of dataset with temporal_resolution" in str(err.value)


### PR DESCRIPTION
Add a check for call to get_gridded_data() for a entry with non-static temporal resolution and without a date_start.
This is to improve the error message you get when someone makes such a query.

Fix an obscure off by one issue in fast_pfb_reader when reading a file for a specific sub grid constraint on a specific file that ended exactly on the boundary of a sub grid in the reminder area of the sub grid. The fix was to change a ">" to ">=". This issue was observed by an external user doing a query with a specific latlon_point query. He had a workaround to change is point slightly, but this fixes the original problem.