### PR TITLE
fix bug in dimension shape preserved

### DIFF
--- a/src/hf_hydrodata/gridded.py
+++ b/src/hf_hydrodata/gridded.py
@@ -2372,6 +2372,8 @@ def _adjust_dimensions(data: np.ndarray, entry: ModelTableRow) -> np.ndarray:
         elif has_z:
             if existing_dim_size == 4 and period == "static":
                 data = data[0, :, :, :]
+            elif existing_dim_size == 5 and period in ["hourly", "daily", "monthly", "weekly"]:
+                data = data[0, :, :, :, :]
 
     return data
 


### PR DESCRIPTION
This PR fixes a bug in which `has_z` is `True` and the `existing_dim_size` is 5 instead of 4. This happens when requesting pressure data for the `ucrb_baseline` dataset. The dataset is currently preserving the additional dimension instead of truncating it as it should.